### PR TITLE
Add Chaos mode support and improve game mode navigation

### DIFF
--- a/src/components/game/WordPathGame.tsx
+++ b/src/components/game/WordPathGame.tsx
@@ -930,10 +930,12 @@ function checkAndAwardAchievements(
 
 function WordPathGame({
   onBackToTitle,
+  onBackToAdvancedModes,
   initialMode = "classic",
   initialPuzzleId
 }: {
   onBackToTitle?: () => void;
+  onBackToAdvancedModes?: () => void;
   initialMode?: "classic" | "daily" | "practice" | "blitz" | "time_attack" | "endless" | "puzzle" | "survival" | "zen" | "chaos";
   initialPuzzleId?: string;
 }) {
@@ -4228,15 +4230,21 @@ function WordPathGame({
           <Button variant="outline" onClick={() => setShowHowToPlay(true)} size="sm" className="bg-background text-[hsl(var(--brand-500))] border-[hsl(var(--brand-500))] hover:bg-[hsl(var(--brand-50))] hover:text-[hsl(var(--brand-600))] dark:hover:bg-[hsl(var(--brand-950))]">
             How to Play
           </Button>
-          
+
+          {onBackToAdvancedModes && (
+            <Button variant="outline" onClick={onBackToAdvancedModes} size="sm" className="bg-background text-[hsl(var(--brand-500))] border-[hsl(var(--brand-500))] hover:bg-[hsl(var(--brand-50))] hover:text-[hsl(var(--brand-600))] dark:hover:bg-[hsl(var(--brand-950))]">
+              Back to Advanced Modes
+            </Button>
+          )}
+
           {settings.mode === "blitz" && blitzStarted && !gameOver && <Button variant="outline" onClick={() => setBlitzPaused(!blitzPaused)} size="sm" className="bg-background text-[hsl(var(--brand-500))] border-[hsl(var(--brand-500))] hover:bg-[hsl(var(--brand-50))] hover:text-[hsl(var(--brand-600))] dark:hover:bg-[hsl(var(--brand-950))] ml-3">
               {blitzPaused ? "▶️ Resume" : "⏸️ Pause"}
             </Button>}
-          
+
           {settings.mode === "classic" && !gameOver && <Button variant="outline" onClick={onEndGame} size="sm" className="bg-background text-[hsl(var(--brand-500))] border-[hsl(var(--brand-500))] hover:bg-[hsl(var(--brand-50))] hover:text-[hsl(var(--brand-600))] dark:hover:bg-[hsl(var(--brand-950))]">
             End Game
           </Button>}
-          
+
           {settings.mode === "endless" && endlessStarted && !gameOver && <Button variant="outline" onClick={async () => {
             // End endless run and collect XP
             const longestWord = usedWords.reduce((longest, wordEntry) => 

--- a/src/lib/gameModes.ts
+++ b/src/lib/gameModes.ts
@@ -1,0 +1,16 @@
+export type AdvancedGameMode = 'classic' | 'time_attack' | 'endless' | 'puzzle' | 'survival' | 'zen' | 'chaos';
+
+export const ADVANCED_MODE_NAMES: Record<AdvancedGameMode, string> = {
+  classic: 'Classic',
+  time_attack: 'Time Attack',
+  endless: '(Almost) Endless',
+  puzzle: 'Puzzle',
+  survival: 'Survival',
+  zen: 'Zen',
+  chaos: 'Chaos'
+};
+
+export function getModeName(mode: AdvancedGameMode | null): string | null {
+  if (!mode) return null;
+  return ADVANCED_MODE_NAMES[mode] || null;
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -8,6 +8,7 @@ import { useProfile } from "@/hooks/useProfile";
 import { calculateLevel } from "@/lib/progression";
 import type { User } from "@supabase/supabase-js";
 import { AdvancedGameModes, AdvancedGameMode } from "@/components/game/AdvancedGameModes";
+import { getModeName } from "@/lib/gameModes";
 import PuzzleSelector from "@/components/game/PuzzleSelector";
 import MiniMarathon from "@/components/game/MiniMarathon";
 import WeeklyGauntlet from "@/components/game/WeeklyGauntlet";
@@ -93,8 +94,9 @@ const Index = () => {
   useEffect(() => {
     const urlParams = new URLSearchParams(window.location.search);
     const mode = urlParams.get('mode');
-    if (mode && ['time_attack', 'endless', 'puzzle', 'survival', 'zen'].includes(mode)) {
+    if (mode && ['time_attack', 'endless', 'puzzle', 'survival', 'zen', 'chaos'].includes(mode)) {
       setSelectedMode(mode as any);
+      setSelectedAdvancedMode(mode as AdvancedGameMode);
       setShowGame(true);
     }
   }, []);
@@ -116,6 +118,13 @@ const Index = () => {
     setShowPrestigeEndless(false);
     setSelectedPuzzleId(null);
     // Refresh profile to get updated XP
+    refreshProfile();
+  };
+  const handleBackToAdvancedModes = () => {
+    setShowGame(false);
+    setShowAdvancedModes(true);
+    setSelectedPuzzleId(null);
+    // Keep selectedAdvancedMode set so user sees their last selection highlighted
     refreshProfile();
   };
   const handleAdvancedModeSelect = (mode: AdvancedGameMode) => {
@@ -150,6 +159,7 @@ const Index = () => {
   const handlePuzzleSelect = (puzzleId: string) => {
     setSelectedPuzzleId(puzzleId);
     setSelectedMode('puzzle');
+    setSelectedAdvancedMode('puzzle');
     setShowPuzzleSelector(false);
     setShowGame(true);
   };
@@ -213,13 +223,16 @@ const Index = () => {
     return <main>
         <header className="container mx-auto pt-10 pb-4">
           <h1 className="text-4xl md:text-5xl font-extrabold tracking-tight bg-clip-text text-transparent bg-gradient-to-r from-[hsl(var(--brand-400))] to-[hsl(var(--brand-600))]">Lexichain</h1>
-          
-          
+          {selectedAdvancedMode && (
+            <p className="text-lg md:text-xl font-semibold text-muted-foreground mt-2 text-center">
+              {getModeName(selectedAdvancedMode)}
+            </p>
+          )}
         </header>
         <Suspense fallback={<div className="flex items-center justify-center py-20">
             <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-brand-500"></div>
           </div>}>
-          <WordPathGame onBackToTitle={handleBackToTitle} initialMode={selectedMode} initialPuzzleId={selectedPuzzleId || undefined} />
+          <WordPathGame onBackToTitle={handleBackToTitle} onBackToAdvancedModes={selectedAdvancedMode ? handleBackToAdvancedModes : undefined} initialMode={selectedMode} initialPuzzleId={selectedPuzzleId || undefined} />
         </Suspense>
       </main>;
   }


### PR DESCRIPTION
## Summary
This PR adds support for the new "Chaos" game mode and improves navigation flow by allowing players to return to the Advanced Modes menu from within a game session.

## Key Changes
- **New Chaos Mode Support**: Added 'chaos' to the list of supported advanced game modes that can be launched via URL parameters
- **Game Mode Utility Library**: Created `src/lib/gameModes.ts` with:
  - `AdvancedGameMode` type definition including the new 'chaos' mode
  - `ADVANCED_MODE_NAMES` mapping for user-friendly mode display names
  - `getModeName()` helper function for retrieving mode display names
- **Improved Navigation**: 
  - Added `handleBackToAdvancedModes()` handler to return to Advanced Modes menu while preserving the selected mode highlight
  - Added "Back to Advanced Modes" button in `WordPathGame` component (conditionally shown when applicable)
  - Updated `WordPathGame` to accept optional `onBackToAdvancedModes` callback
- **Enhanced Mode Tracking**: 
  - Now tracks `selectedAdvancedMode` state separately to maintain mode selection across navigation
  - Display current game mode name in the header when in an advanced mode
  - Properly set `selectedAdvancedMode` when launching modes via URL or puzzle selection

## Implementation Details
- The "Back to Advanced Modes" button only appears when `onBackToAdvancedModes` callback is provided, maintaining backward compatibility
- Mode names are centralized in the new `gameModes.ts` file for easier maintenance and consistency
- The selected advanced mode is preserved when returning from a game, allowing users to see their last selection highlighted in the mode selector

https://claude.ai/code/session_01M7q2dDZhWNWgcAiy5XmUXc