### PR TITLE
Add special tile preview for Daily Challenge mode

### DIFF
--- a/src/components/game/WordPathGame.tsx
+++ b/src/components/game/WordPathGame.tsx
@@ -23,6 +23,8 @@ import { ChevronDown } from "lucide-react";
 import { getDailyChallengeDate } from "@/utils/dateUtils";
 import { saveDailyChallengeResultBulletproof, type SaveProgress } from "@/utils/dailyChallengeResultSaver";
 import { DailyChallengeSaveIndicator } from "@/components/ui/daily-challenge-save-indicator";
+import { SpecialTilePreview } from "@/components/ui/special-tile-preview";
+import { previewNextSpecialTiles } from "@/utils/specialTilePreview";
 import { dictionaryManager } from "@/utils/dictionaryManager";
 import { getPuzzleById, getNextPuzzle, type PuzzleBoard } from "@/lib/puzzleBoards";
 import { useTileSkin } from "@/hooks/useTileSkin";
@@ -5103,9 +5105,26 @@ function WordPathGame({
               <div className="text-xs text-muted-foreground text-right">
                 {usedWords.length >= 1 ? "Special tiles active!" : ""}
                 {gameOver && finalGrade !== "None" && <div className="mt-1 font-medium">Final: {finalGrade}</div>}
-                {settings.mode === "daily" && <div className="mt-1 text-xs text-muted-foreground">
-                    {settings.dailyMovesLimit - movesUsed} moves remaining
-                  </div>}
+                {settings.mode === "daily" && (
+                  <>
+                    <div className="mt-1 text-xs text-muted-foreground">
+                      {settings.dailyMovesLimit - movesUsed} moves remaining
+                    </div>
+                    {!gameOver && (() => {
+                      const nextTiles = previewNextSpecialTiles(
+                        usedWords.length,
+                        getDailySeed(),
+                        size,
+                        specialTiles
+                      );
+                      return nextTiles.length > 0 ? (
+                        <div className="mt-2">
+                          <SpecialTilePreview tiles={nextTiles} />
+                        </div>
+                      ) : null;
+                    })()}
+                  </>
+                )}
                 {settings.mode === "time_attack" && (
                   <div className="mt-1 text-xs">
                     <div className="flex items-center gap-2">

--- a/src/components/ui/special-tile-preview.tsx
+++ b/src/components/ui/special-tile-preview.tsx
@@ -1,0 +1,108 @@
+/**
+ * SpecialTilePreview Component
+ * Displays a preview of special tiles that will appear after the next move
+ * in Daily Challenge mode (without revealing their positions)
+ */
+
+import { SpecialTile } from "@/utils/specialTilePreview";
+import { Card } from "@/components/ui/card";
+
+interface SpecialTilePreviewProps {
+  tiles: SpecialTile[];
+}
+
+export function SpecialTilePreview({ tiles }: SpecialTilePreviewProps) {
+  if (tiles.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col gap-2 p-3 bg-muted/50 rounded-lg border border-border">
+      <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+        Next Special Tile{tiles.length > 1 ? "s" : ""}:
+      </div>
+      <div className="flex gap-2">
+        {tiles.map((tile, index) => (
+          <TileIcon key={index} tile={tile} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function TileIcon({ tile }: { tile: SpecialTile }) {
+  const getTileClasses = () => {
+    let baseClasses =
+      "relative w-12 h-12 flex items-center justify-center rounded-lg transition-all duration-300 ";
+
+    if (tile.type === "stone") {
+      baseClasses +=
+        "bg-gradient-to-br from-gray-400 to-gray-600 text-white shadow-[0_0_15px_rgba(75,85,99,0.4)]";
+    } else if (tile.type === "wild") {
+      baseClasses +=
+        "bg-gradient-to-br from-purple-400 via-pink-400 to-red-400 text-white shadow-[0_0_20px_rgba(236,72,153,0.5)]";
+    } else if (tile.type === "xfactor") {
+      baseClasses +=
+        "bg-gradient-to-br from-orange-400 to-red-500 text-white shadow-[0_0_20px_rgba(251,146,60,0.5)]";
+    } else if (tile.type === "multiplier") {
+      baseClasses +=
+        "bg-gradient-to-br from-blue-400 to-blue-600 text-white shadow-[0_0_20px_rgba(59,130,246,0.5)]";
+    } else if (tile.type === "shuffle") {
+      baseClasses +=
+        "bg-gradient-to-br from-red-200 to-red-300 text-red-800 shadow-[0_0_15px_rgba(239,68,68,0.3)]";
+    }
+
+    return baseClasses;
+  };
+
+  return (
+    <Card className={getTileClasses()}>
+      {/* Icon based on tile type */}
+      {tile.type === "stone" && (
+        <div className="text-2xl opacity-80">🪨</div>
+      )}
+
+      {tile.type === "wild" && (
+        <div className="text-2xl font-bold">?</div>
+      )}
+
+      {tile.type === "xfactor" && (
+        <>
+          <div className="absolute top-1 left-1 w-2 h-2 bg-white/30 rounded-full"></div>
+          <div className="absolute top-1 right-1 w-2 h-2 bg-white/30 rounded-full"></div>
+          <div className="absolute bottom-1 left-1 w-2 h-2 bg-white/30 rounded-full"></div>
+          <div className="absolute bottom-1 right-1 w-2 h-2 bg-white/30 rounded-full"></div>
+        </>
+      )}
+
+      {tile.type === "multiplier" && tile.value && (
+        <div className="text-base font-bold">{tile.value}x</div>
+      )}
+
+      {tile.type === "shuffle" && (
+        <div className="text-sm">
+          <svg
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            className="opacity-60"
+          >
+            <path
+              d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
+              stroke="currentColor"
+              strokeWidth="2"
+            />
+          </svg>
+        </div>
+      )}
+
+      {/* Expiry turns indicator */}
+      {tile.expiryTurns !== undefined && (
+        <div className="absolute top-0.5 left-0.5 text-[10px] font-bold bg-black/30 text-white px-1 rounded-full min-w-[14px] text-center">
+          {tile.expiryTurns}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/src/utils/specialTilePreview.ts
+++ b/src/utils/specialTilePreview.ts
@@ -1,0 +1,125 @@
+/**
+ * Utility for previewing special tiles that will appear after the next move
+ * in Daily Challenge mode.
+ */
+
+export type SpecialTileType = "stone" | "wild" | "xfactor" | "multiplier" | "shuffle";
+
+export interface SpecialTile {
+  type: SpecialTileType | null;
+  value?: number; // For multipliers (2x, 3x, 4x)
+  expiryTurns?: number; // Number of turns until expiry
+}
+
+const SPECIAL_TILE_RARITIES = {
+  stone: 0.15,
+  wild: 0.05,
+  xfactor: 0.08,
+  multiplier: 0.12,
+  shuffle: 0.03,
+};
+
+/**
+ * Seeded random number generator
+ * Creates a deterministic RNG from a string seed
+ */
+function seedRandom(seed: string): () => number {
+  let hash = 0;
+  for (let i = 0; i < seed.length; i++) {
+    const char = seed.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+    hash = hash & hash; // Convert to 32-bit integer
+  }
+  return function () {
+    hash = Math.imul(hash, 0x9e3779b9);
+    hash = hash ^ hash >>> 16;
+    return (hash >>> 0) / 0x100000000;
+  };
+}
+
+/**
+ * Generates a special tile using seeded randomness
+ */
+function generateSeededSpecialTile(rng: () => number): SpecialTile {
+  const rand = rng();
+  let cumulative = 0;
+
+  for (const [type, rarity] of Object.entries(SPECIAL_TILE_RARITIES)) {
+    cumulative += rarity;
+    if (rand <= cumulative) {
+      // Use seeded random for expiry turns (2-4 turns)
+      const expiryTurns = Math.floor(rng() * 3) + 2;
+
+      if (type === "multiplier") {
+        const multiplierValues = [2, 3, 4];
+        const value = multiplierValues[Math.floor(rng() * multiplierValues.length)];
+        return {
+          type: type as SpecialTileType,
+          value,
+          expiryTurns,
+        };
+      }
+      return {
+        type: type as SpecialTileType,
+        expiryTurns,
+      };
+    }
+  }
+  return {
+    type: null,
+  };
+}
+
+/**
+ * Preview what special tiles will appear after the next word is found
+ *
+ * @param currentWordCount - Number of words found so far
+ * @param dailySeed - The daily challenge seed (date string)
+ * @param gridSize - Size of the grid
+ * @param currentSpecialTiles - Current state of special tiles on the board
+ * @returns Array of special tiles that will appear (without position info)
+ */
+export function previewNextSpecialTiles(
+  currentWordCount: number,
+  dailySeed: string,
+  gridSize: number,
+  currentSpecialTiles: SpecialTile[][]
+): SpecialTile[] {
+  // Simulate finding the next word
+  const nextWordCount = currentWordCount + 1;
+
+  // Count empty positions (same logic as introduceSeededSpecialTiles)
+  const emptyPositions: number[] = [];
+  for (let r = 0; r < gridSize; r++) {
+    for (let c = 0; c < gridSize; c++) {
+      if (currentSpecialTiles[r][c].type === null) {
+        emptyPositions.push(r * gridSize + c);
+      }
+    }
+  }
+
+  if (emptyPositions.length === 0) {
+    return [];
+  }
+
+  // Create seeded RNG for the next word count
+  const tileCountRng = seedRandom(dailySeed + "_tiles_" + nextWordCount);
+
+  // Deterministic number of tiles to place (1-3)
+  const numTilesToPlace = Math.floor(tileCountRng() * 3) + 1;
+  const tilesToPlace = Math.min(numTilesToPlace, emptyPositions.length);
+
+  const previewTiles: SpecialTile[] = [];
+
+  // Generate each tile (without revealing position)
+  for (let i = 0; i < tilesToPlace; i++) {
+    const tileRng = seedRandom(dailySeed + "_tile_" + nextWordCount + "_" + i);
+    const specialTile = generateSeededSpecialTile(tileRng);
+
+    if (specialTile.type !== null) {
+      previewTiles.push(specialTile);
+    }
+  }
+
+  return previewTiles;
+}


### PR DESCRIPTION
## Summary
This PR adds a preview feature that shows players which special tiles will appear after their next move in Daily Challenge mode, without revealing their positions on the grid.

## Key Changes
- **New utility module** (`src/utils/specialTilePreview.ts`):
  - Implements seeded random number generator for deterministic tile generation based on daily seed
  - Exports `previewNextSpecialTiles()` function that calculates what special tiles will appear after the next word is found
  - Defines `SpecialTile` interface and `SpecialTileType` enum for type safety
  - Uses the same tile rarity distribution and generation logic as the main game

- **New UI component** (`src/components/ui/special-tile-preview.tsx`):
  - `SpecialTilePreview` component displays upcoming tiles in a compact, visually distinct format
  - `TileIcon` sub-component renders individual tile previews with:
    - Type-specific gradient backgrounds and shadows
    - Visual indicators (emoji, symbols, multiplier values)
    - Expiry turn counter badge
  - Gracefully returns null when no tiles are pending

- **Integration into WordPathGame** (`src/components/game/WordPathGame.tsx`):
  - Calls `previewNextSpecialTiles()` when in daily mode and game is not over
  - Displays preview component below the moves remaining counter
  - Only shows preview when tiles are actually pending

## Implementation Details
- Uses seeded RNG to ensure the same tiles appear for all players on the same day
- Seed combines daily challenge date with word count and tile index for uniqueness
- Preview is calculated on-demand without modifying game state
- Respects empty position availability (won't preview more tiles than can fit)
- Tile generation logic mirrors the main game's `introduceSeededSpecialTiles()` function

https://claude.ai/code/session_01VQn1iojybBnyXxogFQsnw1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure UI/additive utility work gated to Daily Challenge; it doesn’t modify tile spawning/state, only derives a preview from existing state and the daily seed.
> 
> **Overview**
> Adds a **Daily Challenge-only** UI preview that shows which special tile types (and their expiry/multiplier value) will spawn after the *next* word, without revealing board positions.
> 
> Introduces `previewNextSpecialTiles()` (seeded/deterministic from the daily seed + next word count) and a new `SpecialTilePreview` component, then wires it into `WordPathGame` under the daily moves-remaining indicator when the game is in progress.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9ad59b725a7fb47937d54b18cf5983916b34e9c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->