### PR TITLE
Hide Challenge Tiers benchmark display in puzzle mode

### DIFF
--- a/src/components/game/WordPathGame.tsx
+++ b/src/components/game/WordPathGame.tsx
@@ -5425,7 +5425,7 @@ function WordPathGame({
                   </div>
                 )}
                 
-                {benchmarks && settings.mode !== "endless" && <div className="mt-3 space-y-2 p-2 bg-muted/30 rounded-lg border border-muted">
+                {benchmarks && settings.mode !== "endless" && settings.mode !== "puzzle" && <div className="mt-3 space-y-2 p-2 bg-muted/30 rounded-lg border border-muted">
                     <div className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">Challenge Tiers</div>
                     <div className="space-y-1.5">
                       <div className={`flex justify-between items-center text-xs px-2 py-1 rounded transition-all duration-300 ${


### PR DESCRIPTION
## Summary
Updated the WordPathGame component to hide the Challenge Tiers benchmark display when the game is in puzzle mode, in addition to the existing check for endless mode.

## Key Changes
- Modified the conditional rendering logic for the Challenge Tiers section to exclude puzzle mode
- Added `settings.mode !== "puzzle"` check alongside the existing `settings.mode !== "endless"` condition

## Implementation Details
The Challenge Tiers benchmark display is now only shown in standard game modes. This prevents the benchmark information from appearing in both endless and puzzle game modes, which likely don't use or need the tier progression system.

https://claude.ai/code/session_01RmTsDkXBuyxiRm8SDcogaZ