### PR TITLE
Add design document for 8 new special tiles

### DIFF
--- a/docs/special-tiles-design.md
+++ b/docs/special-tiles-design.md
@@ -1,0 +1,137 @@
+# New Special Tiles — Design Document
+
+## Existing Tiles (for reference)
+
+| Tile | Effect |
+|------|--------|
+| Stone | Blocks path — cannot be included in words |
+| Wild (?) | Represents any letter the player chooses |
+| Multiplier (2x/3x/4x) | Multiplies word score |
+| XFactor | Transforms diagonal neighbors into random letters |
+| Shuffle | Reshuffles all letters on the entire board |
+
+---
+
+## Proposed New Tiles
+
+### 1. Freeze Tile ❄️
+
+- **Rarity**: 6%
+- **Effect**: **Locks adjacent tiles in place.** The 4 orthogonal neighbors of a Freeze tile cannot be replaced, shuffled, or transformed by other tile effects (XFactor, Shuffle, board regeneration). They remain exactly as they are until the Freeze tile expires.
+- **Expiry**: 3–5 turns
+- **Strategic value**: Positive — lets players protect key letters they need for future words. Creates interesting tension with Shuffle and XFactor tiles. Also prevents those neighbors from being swapped out during normal board replenishment.
+- **Visual**: Light blue/cyan gradient with a snowflake icon.
+
+---
+
+### 2. Decay Tile 🦠
+
+- **Rarity**: 7%
+- **Effect**: **Spreads each turn.** When a Decay tile's expiry counter ticks down, it has a 40% chance to spread to one random orthogonal neighbor (converting that neighbor's letter to a random low-value letter: A, E, I, O, U, S, T, N, R). The spread copy also becomes a Decay tile with 2 turns remaining. Decay tiles themselves can still be used in words — they just degrade the board over time.
+- **Expiry**: 3 turns (spread copies get 2 turns)
+- **Strategic value**: Negative — creates urgency. Players should use the affected area quickly before vowel-soup takes over. Encourages proactive play.
+- **Visual**: Sickly green/yellow gradient with a splatter texture. Pulses on each spread event.
+
+---
+
+### 3. Mirror Tile 🪞
+
+- **Rarity**: 4%
+- **Effect**: **Duplicates the letter of whichever tile connects to it in the word path.** When used in a word, the Mirror tile copies the letter of the tile immediately before it in the path. Unlike Wild, the player has no choice — it always echoes the predecessor. This makes it excellent for words with double letters (e.g., connecting T → Mirror = T → E → R spells "TTER...").
+- **Expiry**: 2–3 turns
+- **Strategic value**: Positive — enables double-letter words that would otherwise be impossible on the board. Distinct from Wild because the player cannot choose the letter freely.
+- **Visual**: Silver/chrome gradient with a subtle reflection animation. Displays the mirrored letter once placed in a path.
+
+---
+
+### 4. Magnet Tile 🧲
+
+- **Rarity**: 5%
+- **Effect**: **Pulls vowels toward it.** When a Magnet tile spawns, the letters on its 4 orthogonal neighbors are each replaced with a random vowel (A, E, I, O, U) if they aren't vowels already. Non-special tiles only — it won't overwrite other special tiles. This is a one-time effect on spawn.
+- **Expiry**: 3–4 turns (but the effect is instant; the tile itself remains as a normal passable tile with no ongoing effect beyond marking the area)
+- **Strategic value**: Mixed — creates vowel clusters which can be helpful for forming words, but too many vowels in one area can also make consonant-heavy words harder. Distinct from XFactor because it's targeted (vowels only) and affects orthogonal rather than diagonal neighbors.
+- **Visual**: Red/silver horseshoe-magnet gradient. Neighbors briefly animate inward on spawn.
+
+---
+
+### 5. Bomb Tile 💣
+
+- **Rarity**: 4%
+- **Effect**: **Destroys tiles in a radius when used.** When a Bomb tile is included in a submitted word, after scoring, all tiles within Manhattan distance 2 (a diamond shape, ~12 tiles) have their letters replaced with completely new random letters. Special tiles in the blast radius are also cleared. The Bomb tile itself is consumed.
+- **Expiry**: 2 turns (use it or lose it)
+- **Strategic value**: Mixed — powerful board reset for a targeted area. Can break out of dead-end board states, but also destroys any favorable setup nearby. Unlike Shuffle (which rearranges existing letters globally), Bomb generates *new* letters in a *local* area.
+- **Visual**: Dark red/black gradient with a fuse icon. Fuse animates shorter each turn as expiry approaches.
+
+---
+
+### 6. Chain Tile ⛓️
+
+- **Rarity**: 5%
+- **Effect**: **Bonus points for long paths.** When a Chain tile is included in a word, the player earns +10 bonus points for every tile in the path *beyond* 4. Has no effect on words of length 4 or shorter. Stacks if multiple Chain tiles are in the same word.
+- **Expiry**: 3–4 turns
+- **Strategic value**: Positive — rewards building long words. Distinct from Multiplier because it adds a flat per-tile bonus rather than multiplying the total score, making it specifically valuable for long words while Multiplier is universally good.
+- **Visual**: Bronze/copper gradient with a chain-link icon. Glows brighter as the current path grows longer.
+
+---
+
+### 7. Ghost Tile 👻
+
+- **Rarity**: 3%
+- **Effect**: **Pass-through tile.** A Ghost tile can be included in a word path to connect non-adjacent tiles. It contributes no letter to the word — it acts as a "bridge." For example, if tiles F-[Ghost]-N-D are selected, the word is "FND..." with the Ghost skipped for spelling purposes. The path must still be contiguous on the grid. Maximum one Ghost per word.
+- **Expiry**: 2 turns
+- **Strategic value**: Positive — opens up paths across the board by bridging gaps. Distinct from Wild (which contributes a letter) because Ghost contributes nothing — it's purely a path connector.
+- **Visual**: Translucent white/pale gradient with low opacity. The letter underneath is faintly visible.
+
+---
+
+### 8. Tax Tile 💰
+
+- **Rarity**: 8%
+- **Effect**: **Reduces word score by 30%.** If a Tax tile is in the submitted word path, the final score is reduced by 30% (applied after all multipliers). Multiple Tax tiles stack multiplicatively (two Tax tiles = 0.7 × 0.7 = 49% of original score).
+- **Expiry**: 3–5 turns
+- **Strategic value**: Negative — forces players to weigh whether a word through a Tax tile is still worth it. Creates risk/reward decisions, especially when a Tax tile sits between a Multiplier tile and the rest of a high-value path.
+- **Visual**: Gold/yellow gradient with a coin-slash icon. Displays "-30%" at the bottom.
+
+---
+
+## Summary Table
+
+| Tile | Type | Rarity | Core Mechanic | Positive/Negative |
+|------|------|--------|---------------|-------------------|
+| Freeze ❄️ | Passive/area | 6% | Protects neighbors from changes | Positive |
+| Decay 🦠 | Passive/spreading | 7% | Degrades nearby letters over time | Negative |
+| Mirror 🪞 | Path/letter | 4% | Copies previous tile's letter | Positive |
+| Magnet 🧲 | Spawn/area | 5% | Replaces neighbors with vowels | Mixed |
+| Bomb 💣 | Path/area | 4% | Replaces all tiles in radius with new letters | Mixed |
+| Chain ⛓️ | Path/scoring | 5% | Flat bonus per tile beyond length 4 | Positive |
+| Ghost 👻 | Path/bridge | 3% | Bridges non-adjacent tiles (no letter) | Positive |
+| Tax 💰 | Path/scoring | 8% | Reduces final score by 30% | Negative |
+
+## Updated Rarity Budget
+
+| Tile | Rarity |
+|------|--------|
+| Stone | 15% |
+| Multiplier | 12% |
+| XFactor | 8% |
+| **Tax** | **8%** |
+| **Decay** | **7%** |
+| **Freeze** | **6%** |
+| Wild | 5% |
+| **Magnet** | **5%** |
+| **Chain** | **5%** |
+| **Mirror** | **4%** |
+| **Bomb** | **4%** |
+| Shuffle | 3% |
+| **Ghost** | **3%** |
+| *(No special tile)* | *remaining %* |
+
+## Implementation Notes
+
+- All new tiles should follow the existing `SpecialTile` interface (`type`, `value?`, `expiryTurns?`).
+- `SpecialTileType` union should be extended: `"freeze" | "decay" | "mirror" | "magnet" | "bomb" | "chain" | "ghost" | "tax"`.
+- Tiles with spawn-time effects (Magnet, Freeze) should trigger in the tile generation phase.
+- Tiles with per-turn effects (Decay spread) should trigger in the expiry/tick phase.
+- Tiles with path effects (Mirror, Ghost, Bomb, Chain, Tax) should integrate into `submitWord`.
+- Ghost tile requires a modification to word validation — the ghost position's letter must be excluded from the assembled string before dictionary lookup.
+- Mirror tile requires knowing the path order to determine the predecessor tile.

--- a/docs/special-tiles-design.md
+++ b/docs/special-tiles-design.md
@@ -126,6 +126,227 @@
 | **Ghost** | **3%** |
 | *(No special tile)* | *remaining %* |
 
+## Scoring Impact Analysis & Benchmark Adjustments
+
+### Current Scoring Reference
+
+**Formula**: `total = round((base + rarityBonus + lengthBonus) * linkMultiplier * tileMultiplier * consumableMultiplier * modeMultiplier)`
+
+Where `base = L² × 4 + L × 12` (hybrid mode).
+
+| Word Length | Base Score | + Length Bonus | Subtotal |
+|-------------|-----------|----------------|----------|
+| 3 | 72 | 0 | 72 |
+| 4 | 112 | 0 | 112 |
+| 5 | 160 | 25 | 185 |
+| 6 | 216 | 75 | 291 |
+| 7 | 280 | 175 | 455 |
+| 8 | 352 | 325 | 677 |
+
+**Current benchmarks** (fixed across all modes):
+- Bronze: 1,500 | Silver: 2,500 | Gold: 4,000 | Platinum: 6,000
+
+**Daily challenge**: 10 moves. Typical average word score ~150–300 per word, totaling 1,500–3,000 without multiplier luck.
+
+---
+
+### Tile-by-Tile Scoring Impact
+
+#### 1. Chain Tile — Direct Score Inflation
+
+**Mechanism**: +10 per tile beyond length 4, per Chain tile in the path.
+
+| Word Length | Chain Bonus (1 tile) | Chain Bonus (2 tiles) | % of Base Subtotal |
+|-------------|---------------------|-----------------------|--------------------|
+| 5 | +10 | +20 | 5–11% of 185 |
+| 6 | +20 | +40 | 7–14% of 291 |
+| 7 | +30 | +60 | 7–13% of 455 |
+| 8 | +40 | +80 | 6–12% of 677 |
+
+**Verdict**: Modest additive boost. At 5% rarity with 3–4 turn expiry, a player might hit 1–2 Chain tiles per 10-word game. Expected per-game inflation: **+30 to +80 points** (~2–3% of a Gold-tier game). The bonus is flat and additive (applied before multipliers in the subtotal), so it compounds with Multiplier tiles.
+
+**Interaction risk**: A Chain tile on an 8-letter word with a 3x Multiplier tile in the same path: `(677 + 40) × 3 = 2,151` vs. `677 × 3 = 2,031`. Delta of +120, meaningful but not game-breaking since both tiles must be in the same path.
+
+**Recommendation**: No benchmark adjustment needed. Impact is minor and self-limiting (flat bonus, not multiplicative).
+
+---
+
+#### 2. Tax Tile — Direct Score Deflation
+
+**Mechanism**: Final score × 0.7 per Tax tile in the path.
+
+| Scenario | Without Tax | With 1 Tax | With 2 Tax | Score Lost |
+|----------|-------------|------------|------------|------------|
+| 5-letter word, no multiplier | 185 | 130 | 91 | –55 to –94 |
+| 6-letter + 2x multiplier | 582 | 407 | 285 | –175 to –297 |
+| 7-letter + 3x multiplier | 1,365 | 956 | 669 | –409 to –696 |
+
+**Verdict**: Significant per-word impact. At 8% rarity (the highest of any new tile), Tax tiles will appear frequently. Players can often route around them, but on a 4×4 board with limited adjacency, avoidance isn't always possible. Over a 10-word game where ~2–3 words are forced through Tax tiles, expected per-game deflation: **–150 to –400 points**.
+
+**Interaction risk**: Tax stacking with Tax (0.49x) is punishing but very rare. Tax on a Multiplier path (3x × 0.7 = 2.1x) effectively downgrades a 3x to a 2x — still net positive, so players will still take it.
+
+**Recommendation**: **Reduce Bronze benchmark by 100 points** (1,500 → 1,400) to account for the negative pressure Tax puts on average players. Silver/Gold/Platinum players are more likely to route around Tax tiles effectively, so upper benchmarks can remain. Alternatively, keep benchmarks fixed and reduce Tax rarity from 8% → 6% (see consolidated recommendation below).
+
+---
+
+#### 3. Ghost Tile — Indirect Score Inflation via Path Access
+
+**Mechanism**: No direct scoring effect, but enables longer words by bridging gaps.
+
+Ghost doesn't add points itself, but by enabling paths that weren't possible before, it increases average word length. On a 4×4 grid, many 7+ letter words are blocked by adjacency constraints. Ghost relaxes this.
+
+**Estimated impact**: If Ghost enables one additional 7-letter word per game that would have otherwise been a 5-letter word: `455 – 185 = +270 points`. At 3% rarity and 2-turn expiry, this will happen in roughly 1 in 4 games.
+
+**Verdict**: Low frequency, high variance. When it hits, it's strong (+200–400 points from a single upgraded word). Average per-game inflation: **+50 to +100 points**.
+
+**Recommendation**: No benchmark adjustment needed. Rarity (3%) and short expiry (2 turns) already constrain it.
+
+---
+
+#### 4. Mirror Tile — Indirect Score Inflation via Word Access
+
+**Mechanism**: Copies predecessor letter, enabling double-letter words.
+
+Similar to Ghost — no direct points, but enables words like BUTTER, COFFEE, RABBIT that require adjacent duplicate letters. These tend to be 6–8 letter words.
+
+**Estimated impact**: Enables ~1 extra viable word per appearance. At 4% rarity, appears roughly every 2–3 games. When it does appear, it might upgrade a 4-letter word to a 6-letter word: `291 – 112 = +179 points`.
+
+**Verdict**: Moderate positive pressure, similar magnitude to Ghost but slightly more frequent. Average per-game inflation: **+40 to +80 points**.
+
+**Recommendation**: No benchmark adjustment needed.
+
+---
+
+#### 5. Freeze Tile — Indirect Score Stabilization
+
+**Mechanism**: Protects neighbors from Shuffle/XFactor/regeneration.
+
+Freeze doesn't affect scoring directly. It preserves board state, which helps players who plan multi-word strategies around specific letters. This is a skill-rewarding mechanic — better players extract more value.
+
+**Estimated impact**: Hard to quantify. Prevents score *loss* from board disruption rather than adding score. Estimated benefit: **+0 to +50 points** per game, skewed toward skilled players.
+
+**Verdict**: Negligible scoring impact. Primarily a quality-of-life tile.
+
+**Recommendation**: No benchmark adjustment needed.
+
+---
+
+#### 6. Decay Tile — Indirect Score Deflation via Board Degradation
+
+**Mechanism**: Spreads to neighbors (40% chance per turn), converting letters to common low-value ones (A, E, I, O, U, S, T, N, R).
+
+Over 3 turns, one Decay tile can spread to 1–2 neighbors. These neighbors get low-value letters, reducing rarity bonus potential and potentially breaking planned word paths.
+
+**Scoring impact of letter degradation**:
+- A tile changed from K (rare) to E (common) on a 6-letter word path loses: `round(291 × 1 × 0.08) = 23 points` in rarity bonus.
+- A tile changed from Z (ultra-rare) to A: loses `round(291 × 2 × 0.08) + round(291 × 1 × 0.12) = 47 + 35 = 82 points`.
+- Indirect cost of broken paths: unquantifiable but real.
+
+**Estimated impact**: At 7% rarity, Decay appears roughly once per game. With spread, it affects 2–4 tiles total. Expected per-game deflation: **–30 to –100 points** from rarity loss and path disruption.
+
+**Verdict**: Moderate negative pressure. The board degradation effect is more about strategic disruption than raw point loss.
+
+**Recommendation**: No benchmark adjustment needed on its own. Combined with Tax, see consolidated recommendation.
+
+---
+
+#### 7. Magnet Tile — Mixed Score Impact
+
+**Mechanism**: Replaces up to 4 orthogonal neighbors with random vowels on spawn.
+
+Vowel clusters help some words but hurt others. Common vowels (A, E, I, O, U) have 0 rarity value, so replacing rare consonants with vowels loses rarity bonus. But vowels are essential for most English words, so having them nearby is often helpful for path-building.
+
+**Estimated impact**: Net approximately neutral. May lose ~20 points per game in rarity bonus but gain it back through better word accessibility.
+
+**Recommendation**: No benchmark adjustment needed.
+
+---
+
+#### 8. Bomb Tile — Neutral (Variance Increase)
+
+**Mechanism**: Replaces ~12 tiles with new random letters after word submission.
+
+Bomb doesn't affect the score of the word it's used in — the blast happens *after* scoring. It resets a local area, which can be positive (escape dead boards) or negative (destroy good setups). Over many games, this averages out.
+
+**Estimated impact**: ~0 average per-game delta. High variance per individual game.
+
+**Recommendation**: No benchmark adjustment needed.
+
+---
+
+### Consolidated Scoring Impact
+
+| Tile | Per-Game Avg Impact | Direction | Frequency |
+|------|-------------------|-----------|-----------|
+| Chain ⛓️ | +30 to +80 | Positive | ~1–2 tiles/game |
+| Tax 💰 | –150 to –400 | **Negative** | ~2–3 tiles/game |
+| Ghost 👻 | +50 to +100 | Positive | ~0.3 tiles/game |
+| Mirror 🪞 | +40 to +80 | Positive | ~0.4 tiles/game |
+| Freeze ❄️ | +0 to +50 | Positive | ~0.6 tiles/game |
+| Decay 🦠 | –30 to –100 | Negative | ~0.7 tiles/game |
+| Magnet 🧲 | ~0 | Neutral | ~0.5 tiles/game |
+| Bomb 💣 | ~0 | Neutral | ~0.4 tiles/game |
+
+**Net expected per-game shift**: Approximately **–60 to –190 points**, dominated by Tax tile pressure.
+
+Tax is the primary balance concern because it:
+1. Has the highest rarity of any new tile (8%)
+2. Applies a multiplicative penalty (0.7x) *after* all bonuses
+3. Stacks multiplicatively with itself (0.49x for two)
+4. On a 4×4 board, is difficult to consistently avoid
+
+---
+
+### Benchmark Adjustment Recommendations
+
+#### Option A: Adjust Benchmarks (Recommended)
+
+Lower the bottom two thresholds to absorb the net negative pressure from Tax + Decay. Upper tiers stay fixed because skilled players will route around negative tiles more effectively.
+
+| Tier | Current | Proposed | Change | Rationale |
+|------|---------|----------|--------|-----------|
+| Bronze | 1,500 | **1,400** | –100 | Absorbs ~1 forced Tax word for average players |
+| Silver | 2,500 | **2,400** | –100 | Minor relief for intermediate players |
+| Gold | 4,000 | 4,000 | 0 | Skilled players avoid Tax; Chain/Ghost offset Decay |
+| Platinum | 6,000 | 6,000 | 0 | Top players benefit from Chain/Ghost/Mirror |
+
+Also adjust the corresponding goal thresholds:
+- `daily_scorer`: 1,000 → **950** (total daily points)
+- `score_climber`: 1,500 → **1,400** (single game)
+- `high_scorer`: 2,500 → **2,400** (single game)
+
+Survival mode wave targets (`50 + wave × 10` standard, `100 + wave × 15` boss) remain unchanged — survival has a 1.8x mode multiplier that already buffers against per-word penalties.
+
+#### Option B: Adjust Tile Rarity Instead
+
+If benchmarks should remain fixed at the current values, reduce Tax rarity to equalize the negative/positive pressure:
+
+| Tile | Current Proposed Rarity | Adjusted Rarity |
+|------|------------------------|-----------------|
+| Tax | 8% | **5%** |
+| Decay | 7% | **5%** |
+| Chain | 5% | **6%** |
+
+This brings net per-game impact closer to 0, preserving existing benchmarks.
+
+#### Option C: Cap Tax Penalty
+
+Keep Tax at 8% rarity and current benchmarks, but cap the minimum Tax multiplier at 0.6x (instead of allowing 0.7^N stacking). This prevents the worst-case double-Tax scenario (0.49x) while keeping the single-Tax penalty meaningful.
+
+---
+
+### Recommended Approach
+
+**Option A** is recommended because:
+- It preserves the intended frequency and impact of each tile design
+- Bronze/Silver thresholds haven't been dynamically tuned before (they're hardcoded at fixed values), so a small adjustment is low-risk
+- It keeps the balance between positive and negative tiles intentional rather than artificially flattening it
+- Gold and Platinum remain aspirational targets that reward mastery of the full tile system
+
+If playtesting shows the impact is less severe than modeled (e.g., players route around Tax more often than expected on larger boards), the adjustment can be reverted with no system-level consequences since benchmarks are simple constants.
+
+---
+
 ## Implementation Notes
 
 - All new tiles should follow the existing `SpecialTile` interface (`type`, `value?`, `expiryTurns?`).

--- a/src/components/game/WordPathGame.tsx
+++ b/src/components/game/WordPathGame.tsx
@@ -2173,7 +2173,7 @@ function WordPathGame({
 
     // Handle X-Factor tiles first
     const currentBoardForXFactor = newBoard.map(row => [...row]);
-    const xChanged = handleXFactorTiles(
+    const xFactorResult = handleXFactorTiles(
       wordPath, 
       specialTiles, 
       currentBoardForXFactor, 
@@ -2182,9 +2182,10 @@ function WordPathGame({
       setSpecialTiles, 
       setAffectedTiles
     );
+    const xChanged = xFactorResult.xChanged;
 
     // Handle shuffle tiles (use updated board if X-factor was triggered)
-    const currentBoard = xChanged > 0 ? newBoard : currentBoardForXFactor;
+    const currentBoard = xChanged > 0 ? xFactorResult.board : currentBoardForXFactor;
     handleShuffleTiles(
       wordPath, 
       specialTiles, 

--- a/src/components/game/WordPathGame.tsx
+++ b/src/components/game/WordPathGame.tsx
@@ -3709,10 +3709,9 @@ function WordPathGame({
     }
   }
   function tryAddToPath(pos: Pos) {
-    // Ghost tiles can bridge non-adjacent tiles - check if last tile is ghost or current tile is ghost
+    // Ghost tiles can bridge non-adjacent tiles - only when the last tile in path is a ghost
     const lastTile = path.length > 0 ? specialTiles[path[path.length - 1].r][path[path.length - 1].c] : null;
-    const currentTile = specialTiles[pos.r][pos.c];
-    const canSkipAdjacency = lastTile?.type === "ghost" || currentTile.type === "ghost";
+    const canSkipAdjacency = lastTile?.type === "ghost";
     
     if (path.length && !canSkipAdjacency && !neighbors(path[path.length - 1], pos)) return;
     const k = keyOf(pos);
@@ -3905,10 +3904,9 @@ function WordPathGame({
         // If tapping a tile already in path, remove it and all tiles after it
         setPath(path.slice(0, existingIndex));
       } else {
-        // Try to add to path (must be adjacent to last tile, unless ghost tile is involved)
+        // Try to add to path (must be adjacent to last tile, unless last tile is a ghost)
         const lastTile = specialTiles[path[path.length - 1].r][path[path.length - 1].c];
-        const currentTile = specialTiles[pos.r][pos.c];
-        const canSkipAdjacency = lastTile.type === "ghost" || currentTile.type === "ghost";
+        const canSkipAdjacency = lastTile.type === "ghost";
         const isAdjacent = neighbors(path[path.length - 1], pos);
         
         if (path.length && (isAdjacent || canSkipAdjacency)) {

--- a/src/components/game/WordPathGame.tsx
+++ b/src/components/game/WordPathGame.tsx
@@ -424,8 +424,20 @@ function computeScoreBreakdown(params: {
   const linkMultiplier = 1 + sharedTilesCount * 0.15 / (1 + sharedTilesCount * 0.05);
   const linkBonus = 0; // Keep for backward compatibility in UI
 
-  const raritySum = wordPath.reduce((acc, p) => acc + letterRarity(board[p.r][p.c]), 0);
-  const ultraRareCount = wordPath.reduce((acc, p) => acc + (["J", "Q", "X", "Z"].includes(board[p.r][p.c].toUpperCase()) ? 1 : 0), 0);
+  // Calculate rarity based on actual letters in the word (respecting ghost and mirror tiles)
+  const actualLetters: string[] = [];
+  for (let i = 0; i < wordPath.length; i++) {
+    const p = wordPath[i];
+    const tile = specialTiles[p.r][p.c];
+    if (tile.type === "ghost") continue; // Ghost contributes no letter
+    if (tile.type === "mirror" && actualLetters.length > 0) {
+      actualLetters.push(actualLetters[actualLetters.length - 1]); // Copy previous letter
+    } else {
+      actualLetters.push(board[p.r][p.c]);
+    }
+  }
+  const raritySum = actualLetters.reduce((acc, letter) => acc + letterRarity(letter), 0);
+  const ultraRareCount = actualLetters.reduce((acc, letter) => acc + (["J", "Q", "X", "Z"].includes(letter.toUpperCase()) ? 1 : 0), 0);
 
   // NEW: Percentage-based rarity system
   const rarityBonus = Math.round(base * (raritySum * 0.08)) + Math.round(base * (ultraRareCount * 0.12));

--- a/src/components/game/WordPathGame.tsx
+++ b/src/components/game/WordPathGame.tsx
@@ -79,11 +79,13 @@ const within = (r: number, c: number, size: number) => r >= 0 && c >= 0 && r < s
 const neighbors = (a: Pos, b: Pos) => Math.max(Math.abs(a.r - b.r), Math.abs(a.c - b.c)) <= 1;
 
 // Special tile types
-type SpecialTileType = "stone" | "wild" | "xfactor" | "multiplier" | "shuffle" | null;
+type SpecialTileType = "stone" | "wild" | "xfactor" | "multiplier" | "shuffle"
+  | "freeze" | "decay" | "mirror" | "magnet" | "bomb" | "chain" | "ghost" | "tax" | null;
 type SpecialTile = {
   type: SpecialTileType;
   value?: number;
   expiryTurns?: number;
+  frozen?: boolean;
 };
 type GameMode = "classic" | "target" | "daily" | "practice" | "blitz" | "time_attack" | "endless" | "puzzle" | "survival" | "zen" | "chaos";
 type GameSettings = {
@@ -321,6 +323,31 @@ const SPECIAL_TILE_RARITIES = {
   shuffle: 0.03 // Rare occurrence
 };
 
+// Enhanced powerups tile rarities (used when toggle is on and mode is not daily)
+const ENHANCED_TILE_RARITIES: Record<string, number> = {
+  stone: 0.15,
+  multiplier: 0.12,
+  xfactor: 0.08,
+  tax: 0.08,
+  decay: 0.07,
+  freeze: 0.06,
+  wild: 0.05,
+  magnet: 0.05,
+  chain: 0.05,
+  mirror: 0.04,
+  bomb: 0.04,
+  shuffle: 0.03,
+  ghost: 0.03,
+};
+
+function isEnhancedPowerupsEnabled(): boolean {
+  return localStorage.getItem('lexichain-enhanced-powerups') === 'true';
+}
+
+// Common low-value letters used by Decay and Magnet effects
+const LOW_VALUE_LETTERS = ["A", "E", "I", "O", "U", "S", "T", "N", "R"];
+const VOWELS = ["A", "E", "I", "O", "U"];
+
 // Letter rarity helpers (based on frequency with a special bucket for ultra-rare letters)
 const VERY_RARE = new Set(["J", "Q", "X", "Z"]);
 const FREQ_MAP = new Map<string, number>(LETTERS);
@@ -409,6 +436,18 @@ function computeScoreBreakdown(params: {
   if (wordLen >= 6) lengthBonus += 50;
   if (wordLen >= 7) lengthBonus += 100;
   if (wordLen >= 8) lengthBonus += 150;
+
+  // Chain tile: +10 per tile in path beyond 4, per chain tile
+  const chainTilesInPath = wordPath.filter(p => specialTiles[p.r][p.c].type === "chain").length;
+  let chainBonus = 0;
+  if (chainTilesInPath > 0 && wordPath.length > 4) {
+    chainBonus = (wordPath.length - 4) * 10 * chainTilesInPath;
+  }
+
+  // Tax tile: 0.7x per tax tile (applied after all multipliers)
+  const taxTilesInPath = wordPath.filter(p => specialTiles[p.r][p.c].type === "tax").length;
+  const taxMultiplier = taxTilesInPath > 0 ? Math.pow(0.7, taxTilesInPath) : 1;
+
   const timeBonus = 0; // Removed blitz functionality
 
   const scoreMultiplierEffect = activeEffects.find(e => e.id === "score_multiplier");
@@ -446,8 +485,8 @@ function computeScoreBreakdown(params: {
   const combinedMultiplierRaw = tileMultiplier * consumableMultiplier * modeMultiplier;
   const combinedApplied = combinedMultiplierRaw; // No cap - multipliers stack freely
   const capped = false;
-  const totalBeforeMultipliers = Math.round((base + rarityBonus + lengthBonus + timeBonus) * linkMultiplier);
-  const total = Math.round(totalBeforeMultipliers * combinedApplied);
+  const totalBeforeMultipliers = Math.round((base + rarityBonus + lengthBonus + chainBonus + timeBonus) * linkMultiplier);
+  const total = Math.round(totalBeforeMultipliers * combinedApplied * taxMultiplier);
   return {
     base,
     rarity: {
@@ -757,28 +796,30 @@ function handleShuffleTiles(
 ): void {
   const shuffleTiles = wordPath.filter(p => specialTiles[p.r][p.c].type === "shuffle");
   if (shuffleTiles.length > 0) {
-    // Get all letters from the board and ensure max 4 of each letter
+    // Collect letters from non-frozen positions only; frozen tiles stay in place
+    const shuffleablePositions: Pos[] = [];
     const allLetters: string[] = [];
     const letterCounts = new Map<string, number>();
-    
+
     for (let r = 0; r < size; r++) {
       for (let c = 0; c < size; c++) {
         const letter = currentBoard[r][c];
         const count = letterCounts.get(letter) || 0;
         letterCounts.set(letter, count + 1);
-        allLetters.push(letter);
+        if (!specialTiles[r][c].frozen) {
+          shuffleablePositions.push({ r, c });
+          allLetters.push(letter);
+        }
       }
     }
-    
+
     // Check if any letter exceeds 4 instances and replace extras
     for (const [letter, count] of letterCounts) {
       if (count > 4) {
         const excess = count - 4;
-        // Find positions with this letter and replace excess ones
         let replaced = 0;
         for (let i = 0; i < allLetters.length && replaced < excess; i++) {
           if (allLetters[i] === letter) {
-            // Replace with a constrained random letter
             const tempCounts = new Map(letterCounts);
             tempCounts.set(letter, tempCounts.get(letter)! - 1);
             allLetters[i] = constrainedRandomLetter(tempCounts);
@@ -787,20 +828,18 @@ function handleShuffleTiles(
         }
       }
     }
-    
+
     // Shuffle the letters array
     for (let i = allLetters.length - 1; i > 0; i--) {
       const j = Math.floor(Math.random() * (i + 1));
       [allLetters[i], allLetters[j]] = [allLetters[j], allLetters[i]];
     }
-    
-    // Redistribute the shuffled letters
-    let letterIndex = 0;
+
+    // Redistribute the shuffled letters to non-frozen positions only
     const shuffledBoard = currentBoard.map(row => [...row]);
-    for (let r = 0; r < size; r++) {
-      for (let c = 0; c < size; c++) {
-        shuffledBoard[r][c] = allLetters[letterIndex++];
-      }
+    for (let i = 0; i < shuffleablePositions.length; i++) {
+      const { r, c } = shuffleablePositions[i];
+      shuffledBoard[r][c] = allLetters[i];
     }
     
     // Apply Q-U adjacency validation to the shuffled board
@@ -863,11 +902,11 @@ function handleXFactorTiles(
       ];
       
       diagonals.forEach(pos => {
-        if (within(pos.r, pos.c, size)) {
+        if (within(pos.r, pos.c, size) && !newSpecialTiles[pos.r][pos.c].frozen) {
           // Reduce count of old letter
           const oldLetter = newBoard[pos.r][pos.c];
           currentLetterCounts.set(oldLetter, (currentLetterCounts.get(oldLetter) || 0) - 1);
-          
+
           // Generate new constrained letter
           newBoard[pos.r][pos.c] = constrainedRandomLetter(currentLetterCounts);
           newSpecialTiles[pos.r][pos.c] = { type: null };
@@ -895,6 +934,139 @@ function handleXFactorTiles(
   }
   
   return xChanged;
+}
+
+// Apply Magnet spawn effect: replace orthogonal neighbors with random vowels
+function applyMagnetSpawnEffect(
+  pos: Pos,
+  board: string[][],
+  specialTiles: SpecialTile[][],
+  size: number
+): string[][] {
+  const newBoard = board.map(row => [...row]);
+  const orthogonal = [
+    { r: pos.r - 1, c: pos.c },
+    { r: pos.r + 1, c: pos.c },
+    { r: pos.r, c: pos.c - 1 },
+    { r: pos.r, c: pos.c + 1 },
+  ];
+  for (const adj of orthogonal) {
+    if (within(adj.r, adj.c, size) && specialTiles[adj.r][adj.c].type === null) {
+      const currentLetter = newBoard[adj.r][adj.c];
+      if (!VOWELS.includes(currentLetter.toUpperCase())) {
+        newBoard[adj.r][adj.c] = VOWELS[Math.floor(Math.random() * VOWELS.length)];
+      }
+    }
+  }
+  return newBoard;
+}
+
+// Apply Freeze spawn effect: mark orthogonal neighbors as frozen
+function applyFreezeSpawnEffect(
+  pos: Pos,
+  specialTiles: SpecialTile[][],
+  size: number
+): SpecialTile[][] {
+  const newTiles = specialTiles.map(row => row.map(t => ({ ...t })));
+  const orthogonal = [
+    { r: pos.r - 1, c: pos.c },
+    { r: pos.r + 1, c: pos.c },
+    { r: pos.r, c: pos.c - 1 },
+    { r: pos.r, c: pos.c + 1 },
+  ];
+  for (const adj of orthogonal) {
+    if (within(adj.r, adj.c, size)) {
+      newTiles[adj.r][adj.c] = { ...newTiles[adj.r][adj.c], frozen: true };
+    }
+  }
+  return newTiles;
+}
+
+// Process Decay spread during the expiry/tick phase
+function processDecaySpread(
+  specialTiles: SpecialTile[][],
+  board: string[][],
+  size: number
+): { tiles: SpecialTile[][], board: string[][] } {
+  const newTiles = specialTiles.map(row => row.map(t => ({ ...t })));
+  const newBoard = board.map(row => [...row]);
+
+  for (let r = 0; r < size; r++) {
+    for (let c = 0; c < size; c++) {
+      if (specialTiles[r][c].type === "decay") {
+        // 40% chance to spread to one random orthogonal neighbor
+        if (Math.random() < 0.4) {
+          const orthogonal = [
+            { r: r - 1, c: c },
+            { r: r + 1, c: c },
+            { r: r, c: c - 1 },
+            { r: r, c: c + 1 },
+          ].filter(p => within(p.r, p.c, size) && newTiles[p.r][p.c].type === null && !newTiles[p.r][p.c].frozen);
+
+          if (orthogonal.length > 0) {
+            const target = orthogonal[Math.floor(Math.random() * orthogonal.length)];
+            // Convert neighbor's letter to a random low-value letter
+            newBoard[target.r][target.c] = LOW_VALUE_LETTERS[Math.floor(Math.random() * LOW_VALUE_LETTERS.length)];
+            // Spread copy becomes decay with 2 turns
+            newTiles[target.r][target.c] = { type: "decay", expiryTurns: 2 };
+          }
+        }
+      }
+    }
+  }
+  return { tiles: newTiles, board: newBoard };
+}
+
+// Handle Bomb blast: replace all tiles within Manhattan distance 2 with new random letters
+function handleBombBlast(
+  bombPos: Pos,
+  board: string[][],
+  specialTiles: SpecialTile[][],
+  size: number,
+  setBoard: (board: string[][]) => void,
+  setSpecialTiles: (tiles: SpecialTile[][]) => void,
+  setAffectedTiles: (tiles: Set<string>) => void
+): void {
+  const newBoard = board.map(row => [...row]);
+  const newTiles = specialTiles.map(row => row.map(t => ({ ...t })));
+  const changedKeys = new Set<string>();
+  const letterCounts = new Map<string, number>();
+
+  // Count existing letters for constraint
+  for (let r = 0; r < size; r++) {
+    for (let c = 0; c < size; c++) {
+      const letter = newBoard[r][c];
+      letterCounts.set(letter, (letterCounts.get(letter) || 0) + 1);
+    }
+  }
+
+  for (let r = 0; r < size; r++) {
+    for (let c = 0; c < size; c++) {
+      const dist = Math.abs(r - bombPos.r) + Math.abs(c - bombPos.c);
+      if (dist <= 2 && !(r === bombPos.r && c === bombPos.c)) {
+        // Skip frozen tiles
+        if (newTiles[r][c].frozen) continue;
+        // Replace letter
+        const oldLetter = newBoard[r][c];
+        letterCounts.set(oldLetter, (letterCounts.get(oldLetter) || 0) - 1);
+        newBoard[r][c] = constrainedRandomLetter(letterCounts);
+        // Clear special tile
+        newTiles[r][c] = { type: null };
+        changedKeys.add(keyOf({ r, c }));
+      }
+    }
+  }
+
+  // Clear the bomb itself
+  newTiles[bombPos.r][bombPos.c] = { type: null };
+
+  const validation = validateAndFixQUAdjacency(newBoard, size, letterCounts, undefined, true);
+  setBoard(validation.board);
+  setSpecialTiles(newTiles);
+  setAffectedTiles(changedKeys);
+
+  setTimeout(() => setAffectedTiles(new Set()), 1500);
+  toast.info("Bomb detonated! Area reset with new letters!");
 }
 
 function checkAndAwardAchievements(
@@ -1703,16 +1875,41 @@ function WordPathGame({
       }
     }
   }, [dict, sorted, settings.mode, board, benchmarks, isGenerating, settings.difficulty]);
-  const wordFromPath = useMemo(() => board ? path.map(p => board[p.r][p.c]).join("").toLowerCase() : "", [path, board]);
-
-  // Display version that shows ? for Wild tiles during selection
-  const displayWordFromPath = useMemo(() => {
-    return path.map(p => {
-      if (specialTiles[p.r][p.c].type === "wild") {
-        return "?";
+  // Resolves the word from the path, handling Ghost (skip) and Mirror (copy previous) tiles
+  const wordFromPath = useMemo(() => {
+    if (!board) return "";
+    const letters: string[] = [];
+    for (let i = 0; i < path.length; i++) {
+      const p = path[i];
+      const tile = specialTiles[p.r][p.c];
+      if (tile.type === "ghost") continue; // Ghost contributes no letter
+      if (tile.type === "mirror" && letters.length > 0) {
+        letters.push(letters[letters.length - 1]); // Copy previous letter
+      } else {
+        letters.push(board[p.r][p.c]);
       }
-      return board[p.r][p.c];
-    }).join("").toUpperCase();
+    }
+    return letters.join("").toLowerCase();
+  }, [path, board, specialTiles]);
+
+  // Display version that shows ? for Wild, Ghost as a bridge icon, Mirror as mirrored letter
+  const displayWordFromPath = useMemo(() => {
+    const parts: string[] = [];
+    for (let i = 0; i < path.length; i++) {
+      const p = path[i];
+      const tile = specialTiles[p.r][p.c];
+      if (tile.type === "wild") {
+        parts.push("?");
+      } else if (tile.type === "ghost") {
+        // Ghost is skipped in display — it contributes no letter
+        continue;
+      } else if (tile.type === "mirror" && parts.length > 0) {
+        parts.push(parts[parts.length - 1]);
+      } else {
+        parts.push(board[p.r][p.c]);
+      }
+    }
+    return parts.join("").toUpperCase();
   }, [path, board, specialTiles]);
   function handleWildSubmit() {
     if (!pendingWildPath || !wildTileInputs.size || !dict) return;
@@ -2373,6 +2570,14 @@ function WordPathGame({
             if (specialTile.type === "wild") {
               newWildPositions.push(keyOf(pos));
             }
+            // Apply spawn effects for enhanced tiles
+            if (specialTile.type === "magnet") {
+              const magnetBoard = applyMagnetSpawnEffect(pos, board, updatedSpecialTiles, size);
+              setBoard(magnetBoard);
+            }
+            if (specialTile.type === "freeze") {
+              updatedSpecialTiles = applyFreezeSpawnEffect(pos, updatedSpecialTiles, size);
+            }
           }
         }
       }
@@ -2574,50 +2779,46 @@ function WordPathGame({
   function generateSpecialTile(currentScore: number = 0, gameMode: string = "classic", endlessDifficultyLevel: number = 1): SpecialTile {
     const rand = Math.random();
     let cumulative = 0;
-    
+
+    // Use enhanced rarities if toggle is on and mode is not daily
+    const useEnhanced = isEnhancedPowerupsEnabled() && gameMode !== "daily";
+    const baseRarities: Record<string, number> = useEnhanced ? { ...ENHANCED_TILE_RARITIES } : { ...SPECIAL_TILE_RARITIES };
+
     // Progressive stone spawning for classic mode
-    const modifiedRarities = { ...SPECIAL_TILE_RARITIES };
     if (gameMode === "classic") {
       // Progressive stone spawn rate: base 0.05 + (score/1000) * 0.10, capped at 0.35
       const baseStoneRate = 0.05;
       const progressiveRate = Math.min(0.25, (currentScore / 1000) * 0.10);
-      modifiedRarities.stone = baseStoneRate + progressiveRate;
+      baseRarities.stone = baseStoneRate + progressiveRate;
     } else if (gameMode === "endless") {
       // Endless mode: difficulty affects special tile rarities
-      // As difficulty increases, stone tiles become MORE common (making it harder)
-      const difficultyFactor = Math.min(1.0, endlessDifficultyLevel / 10); // Normalize to 0-1 over 10 levels
-      
-      // Increase stone spawn rate as difficulty increases (makes it progressively harder)
-      // Base rate 0.15, increases to 0.40 at level 10+
-      const baseStoneRate = SPECIAL_TILE_RARITIES.stone;
+      const difficultyFactor = Math.min(1.0, endlessDifficultyLevel / 10);
+
+      const baseStoneRate = 0.15;
       const maxStoneRate = 0.40;
-      modifiedRarities.stone = baseStoneRate + (maxStoneRate - baseStoneRate) * difficultyFactor;
-      
-      // Slightly reduce helpful tiles as difficulty increases (but not as much as stones increase)
-      const helpfulReduction = 1 - difficultyFactor * 0.3; // Reduce by up to 30% at max difficulty
-      modifiedRarities.wild = SPECIAL_TILE_RARITIES.wild * helpfulReduction;
-      modifiedRarities.multiplier = SPECIAL_TILE_RARITIES.multiplier * helpfulReduction;
-      modifiedRarities.xfactor = SPECIAL_TILE_RARITIES.xfactor * helpfulReduction;
-      
+      baseRarities.stone = baseStoneRate + (maxStoneRate - baseStoneRate) * difficultyFactor;
+
+      const helpfulReduction = 1 - difficultyFactor * 0.3;
+      baseRarities.wild = (baseRarities.wild || 0.05) * helpfulReduction;
+      baseRarities.multiplier = (baseRarities.multiplier || 0.12) * helpfulReduction;
+      baseRarities.xfactor = (baseRarities.xfactor || 0.08) * helpfulReduction;
+
       // Normalize rarities to ensure they sum to a reasonable probability
-      const totalRarity = Object.values(modifiedRarities).reduce((sum, r) => sum + r, 0);
+      const totalRarity = Object.values(baseRarities).reduce((sum, r) => sum + r, 0);
       if (totalRarity > 0.5) {
-        // Scale down if too high
         const scale = 0.5 / totalRarity;
-        Object.keys(modifiedRarities).forEach(key => {
-          modifiedRarities[key as keyof typeof modifiedRarities] *= scale;
+        Object.keys(baseRarities).forEach(key => {
+          baseRarities[key] *= scale;
         });
       }
     }
-    
-    for (const [type, rarity] of Object.entries(modifiedRarities)) {
+
+    for (const [type, rarity] of Object.entries(baseRarities)) {
       cumulative += rarity;
       if (rand <= cumulative) {
-        // Calculate expiry turns based on tile type and game mode
+        // Calculate expiry turns based on tile type
         let expiryTurns: number;
         if (type === "stone" && gameMode === "endless") {
-          // Stone tiles in endless mode last longer as difficulty increases
-          // Base: 3-5 turns, increases to 8-12 turns at difficulty 10+
           const difficultyFactor = Math.min(1.0, endlessDifficultyLevel / 10);
           const baseMin = 3;
           const baseMax = 5;
@@ -2627,10 +2828,10 @@ function WordPathGame({
           const maxTurns = Math.floor(baseMax + (maxMax - baseMax) * difficultyFactor);
           expiryTurns = Math.floor(Math.random() * (maxTurns - minTurns + 1)) + minTurns;
         } else {
-          // Default expiry: Random 1-5 turns for other tiles/modes
-          expiryTurns = Math.floor(Math.random() * 5) + 1;
+          // Tile-specific expiry ranges
+          expiryTurns = getExpiryTurnsForType(type);
         }
-        
+
         if (type === "multiplier") {
           const multiplierValues = [2, 3, 4];
           const value = multiplierValues[Math.floor(Math.random() * multiplierValues.length)];
@@ -2649,6 +2850,21 @@ function WordPathGame({
     return {
       type: null
     };
+  }
+
+  // Returns appropriate expiry turns for each tile type
+  function getExpiryTurnsForType(type: string): number {
+    switch (type) {
+      case "freeze": return Math.floor(Math.random() * 3) + 3;   // 3-5
+      case "decay": return 3;
+      case "mirror": return Math.floor(Math.random() * 2) + 2;   // 2-3
+      case "magnet": return Math.floor(Math.random() * 2) + 3;   // 3-4
+      case "bomb": return 2;
+      case "chain": return Math.floor(Math.random() * 2) + 3;    // 3-4
+      case "ghost": return 2;
+      case "tax": return Math.floor(Math.random() * 3) + 3;      // 3-5
+      default: return Math.floor(Math.random() * 5) + 1;         // 1-5 (existing tiles)
+    }
   }
   function shouldIntroduceSpecialTiles(wordCount: number): boolean {
     return wordCount >= 1;
@@ -3728,6 +3944,12 @@ function WordPathGame({
       toast.error("Cannot use words containing Stone tiles!");
       return clearPath();
     }
+    // Ghost tile: maximum one per word
+    const ghostCount = path.filter(p => specialTiles[p.r][p.c].type === "ghost").length;
+    if (ghostCount > 1) {
+      toast.error("Only one Ghost tile per word!");
+      return clearPath();
+    }
     if (lastWordTiles.size > 0) {
       const overlap = path.some(p => lastWordTiles.has(keyOf(p)));
       if (!overlap) {
@@ -3878,6 +4100,15 @@ function WordPathGame({
       setAffectedTiles
     );
 
+    // Handle Bomb tile blasts (after scoring, before clearing path tiles)
+    const bombTilesInPath = path.filter(p => specialTiles[p.r][p.c].type === "bomb");
+    if (bombTilesInPath.length > 0) {
+      const latestBoard = board.map(row => [...row]);
+      for (const bombPos of bombTilesInPath) {
+        handleBombBlast(bombPos, latestBoard, specialTiles, size, setBoard, setSpecialTiles, setAffectedTiles);
+      }
+    }
+
     let newSpecialTiles = specialTiles.map(row => [...row]);
     path.forEach(p => {
       if (specialTiles[p.r][p.c].type !== null) {
@@ -3886,7 +4117,35 @@ function WordPathGame({
         };
       }
     });
+
+    // Process Decay spread before expiry (enhanced powerups only, not daily)
+    if (isEnhancedPowerupsEnabled() && settings.mode !== "daily") {
+      const decayResult = processDecaySpread(newSpecialTiles, board, size);
+      newSpecialTiles = decayResult.tiles;
+      setBoard(decayResult.board);
+    }
+
     newSpecialTiles = expireSpecialTiles(newSpecialTiles);
+
+    // Clear frozen flags from tiles whose adjacent Freeze tile expired
+    for (let r = 0; r < size; r++) {
+      for (let c = 0; c < size; c++) {
+        if (newSpecialTiles[r][c].frozen) {
+          // Check if any adjacent tile is still a Freeze tile
+          const orthogonal = [
+            { r: r - 1, c: c }, { r: r + 1, c: c },
+            { r: r, c: c - 1 }, { r: r, c: c + 1 },
+          ];
+          const stillFrozen = orthogonal.some(
+            adj => within(adj.r, adj.c, size) && newSpecialTiles[adj.r][adj.c].type === "freeze"
+          );
+          if (!stillFrozen) {
+            newSpecialTiles[r][c] = { ...newSpecialTiles[r][c], frozen: false };
+          }
+        }
+      }
+    }
+
     setSpecialTiles(newSpecialTiles);
     setLastWordTiles(new Set(path.map(keyOf)));
 
@@ -3982,6 +4241,14 @@ function WordPathGame({
             // Track newly spawned Wild tiles
             if (specialTile.type === "wild") {
               newWildPositions.push(keyOf(pos));
+            }
+            // Apply spawn effects for enhanced tiles
+            if (specialTile.type === "magnet") {
+              const magnetBoard = applyMagnetSpawnEffect(pos, board, updatedSpecialTiles, size);
+              setBoard(magnetBoard);
+            }
+            if (specialTile.type === "freeze") {
+              updatedSpecialTiles = applyFreezeSpawnEffect(pos, updatedSpecialTiles, size);
             }
           }
         }
@@ -5099,6 +5366,22 @@ function WordPathGame({
                   baseClasses += "bg-gradient-to-br from-blue-400 to-blue-600 text-white shadow-[0_0_20px_rgba(59,130,246,0.5)] ";
                 } else if (special.type === "shuffle") {
                   baseClasses += "bg-gradient-to-br from-red-200 to-red-300 text-red-800 shadow-[0_0_15px_rgba(239,68,68,0.3)] ";
+                } else if (special.type === "freeze") {
+                  baseClasses += "bg-gradient-to-br from-cyan-300 to-blue-400 text-white shadow-[0_0_20px_rgba(34,211,238,0.5)] ";
+                } else if (special.type === "decay") {
+                  baseClasses += "bg-gradient-to-br from-yellow-300 to-green-500 text-white shadow-[0_0_15px_rgba(132,204,22,0.4)] ";
+                } else if (special.type === "mirror") {
+                  baseClasses += "bg-gradient-to-br from-gray-200 to-gray-400 text-gray-800 shadow-[0_0_20px_rgba(156,163,175,0.5)] ";
+                } else if (special.type === "magnet") {
+                  baseClasses += "bg-gradient-to-br from-red-400 to-gray-400 text-white shadow-[0_0_15px_rgba(248,113,113,0.4)] ";
+                } else if (special.type === "bomb") {
+                  baseClasses += "bg-gradient-to-br from-red-600 to-gray-900 text-white shadow-[0_0_20px_rgba(220,38,38,0.5)] ";
+                } else if (special.type === "chain") {
+                  baseClasses += "bg-gradient-to-br from-amber-500 to-amber-700 text-white shadow-[0_0_15px_rgba(217,119,6,0.4)] ";
+                } else if (special.type === "ghost") {
+                  baseClasses += "bg-gradient-to-br from-white/60 to-gray-200/60 text-gray-400 shadow-[0_0_15px_rgba(255,255,255,0.3)] opacity-70 ";
+                } else if (special.type === "tax") {
+                  baseClasses += "bg-gradient-to-br from-yellow-400 to-yellow-600 text-white shadow-[0_0_15px_rgba(234,179,8,0.4)] ";
                 }
                 return baseClasses;
               };
@@ -5151,7 +5434,7 @@ function WordPathGame({
                   )}
                   
                   <div className="text-3xl font-semibold tracking-wide relative z-10">
-                    {special.type === "wild" ? "?" : ch}
+                    {special.type === "wild" ? "?" : special.type === "mirror" ? "🪞" : special.type === "ghost" ? ch : ch}
                   </div>
                   {/* Rarity indicators */}
                   {special.type !== "wild" && letterRarity(ch) === 1 && <div className="absolute top-0.5 right-0.5 text-xs font-bold text-orange-600 dark:text-orange-400 z-10">
@@ -5181,6 +5464,15 @@ function WordPathGame({
                   {special.type === "stone" && <div className="absolute bottom-0.5 right-0.5 text-xs opacity-80">
                       🪨
                     </div>}
+                  {special.type === "freeze" && <div className="absolute bottom-0.5 right-0.5 text-xs opacity-80">❄️</div>}
+                  {special.type === "decay" && <div className="absolute bottom-0.5 right-0.5 text-xs opacity-80">🦠</div>}
+                  {special.type === "mirror" && <div className="absolute bottom-0.5 right-0.5 text-xs opacity-80">🪞</div>}
+                  {special.type === "magnet" && <div className="absolute bottom-0.5 right-0.5 text-xs opacity-80">🧲</div>}
+                  {special.type === "bomb" && <div className="absolute bottom-0.5 right-0.5 text-xs opacity-80">💣</div>}
+                  {special.type === "chain" && <div className="absolute bottom-0.5 right-0.5 text-xs opacity-80">⛓️</div>}
+                  {special.type === "ghost" && <div className="absolute bottom-0.5 right-0.5 text-xs opacity-80">👻</div>}
+                  {special.type === "tax" && <div className="absolute bottom-0.5 right-0.5 text-xs opacity-80">💰</div>}
+                  {special.frozen && <div className="absolute top-0 right-0 text-xs opacity-60">❄</div>}
                 </Card>;
             }))}
             {!board && <div className="col-span-full flex items-center justify-center p-8">

--- a/src/components/game/WordPathGame.tsx
+++ b/src/components/game/WordPathGame.tsx
@@ -1919,14 +1919,24 @@ function WordPathGame({
     const wildPos = wildcardPositions[0];
     const wildIndex = pendingWildPath.findIndex(p => p.r === wildPos.r && p.c === wildPos.c);
 
-    // Create the word with the user's chosen letter
-    const testWord = pendingWildPath.map((p, i) => {
+    // Create the word with the user's chosen letter, respecting ghost/mirror behavior
+    const letters: string[] = [];
+    for (let i = 0; i < pendingWildPath.length; i++) {
+      const p = pendingWildPath[i];
+      const tile = specialTiles[p.r][p.c];
+      
       if (i === wildIndex) {
         const wildKey = `${wildPos.r}-${wildPos.c}`;
-        return (wildTileInputs.get(wildKey) || '').toLowerCase();
+        letters.push((wildTileInputs.get(wildKey) || '').toLowerCase());
+      } else if (tile.type === "ghost") {
+        continue; // Ghost contributes no letter
+      } else if (tile.type === "mirror" && letters.length > 0) {
+        letters.push(letters[letters.length - 1]); // Copy previous letter
+      } else {
+        letters.push(board[p.r][p.c]);
       }
-      return board[p.r][p.c];
-    }).join("").toLowerCase();
+    }
+    const testWord = letters.join("").toLowerCase();
 
     // Validate the word using enhanced dictionary manager
     const validation = dictionaryManager.validateWord(testWord);
@@ -3913,6 +3923,14 @@ function WordPathGame({
     }
     const actualWord = wordFromPath;
     const wildUsed = false;
+    
+    // Ghost tile: maximum one per word (check before wild dialog to enforce limit)
+    const ghostCount = path.filter(p => specialTiles[p.r][p.c].type === "ghost").length;
+    if (ghostCount > 1) {
+      toast.error("Only one Ghost tile per word!");
+      return clearPath();
+    }
+    
     const hasWildTile = path.some(p => specialTiles[p.r][p.c].type === "wild");
     if (hasWildTile && dict) {
       const wildcardPositions = path.filter(p => specialTiles[p.r][p.c].type === "wild");
@@ -3943,12 +3961,6 @@ function WordPathGame({
     const hasStoneTile = path.some(p => specialTiles[p.r][p.c].type === "stone");
     if (hasStoneTile) {
       toast.error("Cannot use words containing Stone tiles!");
-      return clearPath();
-    }
-    // Ghost tile: maximum one per word
-    const ghostCount = path.filter(p => specialTiles[p.r][p.c].type === "ghost").length;
-    if (ghostCount > 1) {
-      toast.error("Only one Ghost tile per word!");
       return clearPath();
     }
     if (lastWordTiles.size > 0) {

--- a/src/components/game/WordPathGame.tsx
+++ b/src/components/game/WordPathGame.tsx
@@ -4145,6 +4145,7 @@ function WordPathGame({
     path.forEach(p => {
       if (specialTiles[p.r][p.c].type !== null) {
         newSpecialTiles[p.r][p.c] = {
+          ...specialTiles[p.r][p.c],
           type: null
         };
       }

--- a/src/components/game/WordPathGame.tsx
+++ b/src/components/game/WordPathGame.tsx
@@ -2180,38 +2180,77 @@ function WordPathGame({
       }]);
     }
 
-    // Handle X-Factor tiles first
-    const currentBoardForXFactor = newBoard.map(row => [...row]);
+    // Handle X-Factor tiles first and track board state through all effects
+    let trackedBoard = newBoard.map(row => [...row]);
     const xFactorResult = handleXFactorTiles(
       wordPath, 
       specialTiles, 
-      currentBoardForXFactor, 
+      trackedBoard, 
       size, 
       setBoard, 
       setSpecialTiles, 
       setAffectedTiles
     );
     const xChanged = xFactorResult.xChanged;
+    trackedBoard = xFactorResult.board;
 
-    // Handle shuffle tiles (use updated board if X-factor was triggered)
-    const currentBoard = xChanged > 0 ? xFactorResult.board : currentBoardForXFactor;
-    handleShuffleTiles(
+    // Handle shuffle tiles (use updated board from X-factor)
+    trackedBoard = handleShuffleTiles(
       wordPath, 
       specialTiles, 
-      currentBoard, 
+      trackedBoard, 
       size, 
       setBoard, 
       setAffectedTiles
     );
+
+    // Handle Bomb tile blasts (after scoring, before clearing path tiles)
+    const bombTilesInPath = wordPath.filter(p => specialTiles[p.r][p.c].type === "bomb");
+    if (bombTilesInPath.length > 0) {
+      for (const bombPos of bombTilesInPath) {
+        trackedBoard = handleBombBlast(bombPos, trackedBoard, specialTiles, size, setBoard, setSpecialTiles, setAffectedTiles);
+      }
+    }
+
     let newSpecialTiles = specialTiles.map(row => [...row]);
     wordPath.forEach(p => {
       if (specialTiles[p.r][p.c].type !== null) {
         newSpecialTiles[p.r][p.c] = {
+          ...specialTiles[p.r][p.c],
           type: null
         };
       }
     });
+
+    // Process Decay spread before expiry (enhanced powerups only, not daily)
+    if (isEnhancedPowerupsEnabled() && settings.mode !== "daily") {
+      const decayResult = processDecaySpread(newSpecialTiles, trackedBoard, size);
+      newSpecialTiles = decayResult.tiles;
+      trackedBoard = decayResult.board;
+      setBoard(trackedBoard);
+    }
+
     newSpecialTiles = expireSpecialTiles(newSpecialTiles);
+
+    // Clear frozen flags from tiles whose adjacent Freeze tile expired
+    for (let r = 0; r < size; r++) {
+      for (let c = 0; c < size; c++) {
+        if (newSpecialTiles[r][c].frozen) {
+          // Check if any adjacent tile is still a Freeze tile
+          const orthogonal = [
+            { r: r - 1, c: c }, { r: r + 1, c: c },
+            { r: r, c: c - 1 }, { r: r, c: c + 1 },
+          ];
+          const stillFrozen = orthogonal.some(
+            adj => within(adj.r, adj.c, size) && newSpecialTiles[adj.r][adj.c].type === "freeze"
+          );
+          if (!stillFrozen) {
+            newSpecialTiles[r][c] = { ...newSpecialTiles[r][c], frozen: false };
+          }
+        }
+      }
+    }
+
     setSpecialTiles(newSpecialTiles);
     setLastWordTiles(new Set(wordPath.map(keyOf)));
 

--- a/src/components/game/WordPathGame.tsx
+++ b/src/components/game/WordPathGame.tsx
@@ -1011,11 +1011,11 @@ function processDecaySpread(
           ].filter(p => within(p.r, p.c, size) && newTiles[p.r][p.c].type === null && !newTiles[p.r][p.c].frozen);
 
           if (orthogonal.length > 0) {
-            const target = orthogonal[Math.floor(Math.random() * orthogonal.length)];
-            // Convert neighbor's letter to a random low-value letter
-            newBoard[target.r][target.c] = LOW_VALUE_LETTERS[Math.floor(Math.random() * LOW_VALUE_LETTERS.length)];
-            // Spread copy becomes decay with 2 turns
-            newTiles[target.r][target.c] = { type: "decay", expiryTurns: 2 };
+          const target = orthogonal[Math.floor(Math.random() * orthogonal.length)];
+          // Convert neighbor's letter to a random low-value letter
+          newBoard[target.r][target.c] = LOW_VALUE_LETTERS[Math.floor(Math.random() * LOW_VALUE_LETTERS.length)];
+          // Spread copy becomes decay with 2 turns (set to 3 since expireSpecialTiles decrements in same turn)
+          newTiles[target.r][target.c] = { type: "decay", expiryTurns: 3 };
           }
         }
       }

--- a/src/components/game/WordPathGame.tsx
+++ b/src/components/game/WordPathGame.tsx
@@ -1026,7 +1026,7 @@ function handleBombBlast(
   setBoard: (board: string[][]) => void,
   setSpecialTiles: (tiles: SpecialTile[][]) => void,
   setAffectedTiles: (tiles: Set<string>) => void
-): void {
+): SpecialTile[][] {
   const newBoard = board.map(row => [...row]);
   const newTiles = specialTiles.map(row => row.map(t => ({ ...t })));
   const changedKeys = new Set<string>();
@@ -1062,11 +1062,12 @@ function handleBombBlast(
 
   const validation = validateAndFixQUAdjacency(newBoard, size, letterCounts, undefined, true);
   setBoard(validation.board);
-  setSpecialTiles(newTiles);
   setAffectedTiles(changedKeys);
 
   setTimeout(() => setAffectedTiles(new Set()), 1500);
   toast.info("Bomb detonated! Area reset with new letters!");
+  
+  return newTiles;
 }
 
 function checkAndAwardAchievements(
@@ -4102,14 +4103,13 @@ function WordPathGame({
 
     // Handle Bomb tile blasts (after scoring, before clearing path tiles)
     const bombTilesInPath = path.filter(p => specialTiles[p.r][p.c].type === "bomb");
+    let newSpecialTiles = specialTiles.map(row => [...row]);
     if (bombTilesInPath.length > 0) {
       const latestBoard = board.map(row => [...row]);
       for (const bombPos of bombTilesInPath) {
-        handleBombBlast(bombPos, latestBoard, specialTiles, size, setBoard, setSpecialTiles, setAffectedTiles);
+        newSpecialTiles = handleBombBlast(bombPos, latestBoard, newSpecialTiles, size, setBoard, setSpecialTiles, setAffectedTiles);
       }
     }
-
-    let newSpecialTiles = specialTiles.map(row => [...row]);
     path.forEach(p => {
       if (specialTiles[p.r][p.c].type !== null) {
         newSpecialTiles[p.r][p.c] = {

--- a/src/components/game/WordPathGame.tsx
+++ b/src/components/game/WordPathGame.tsx
@@ -346,7 +346,7 @@ function isEnhancedPowerupsEnabled(): boolean {
 
 // Common low-value letters used by Decay and Magnet effects
 const LOW_VALUE_LETTERS = ["A", "E", "I", "O", "U", "S", "T", "N", "R"];
-const VOWELS = ["A", "E", "I", "O", "U"];
+const MAGNET_VOWELS = ["A", "E", "I", "O", "U"];
 
 // Letter rarity helpers (based on frequency with a special bucket for ultra-rare letters)
 const VERY_RARE = new Set(["J", "Q", "X", "Z"]);
@@ -793,8 +793,10 @@ function handleShuffleTiles(
   size: number,
   setBoard: (board: string[][]) => void,
   setAffectedTiles: (tiles: Set<string>) => void
-): void {
+): string[][] {
   const shuffleTiles = wordPath.filter(p => specialTiles[p.r][p.c].type === "shuffle");
+  let resultBoard = currentBoard;
+  
   if (shuffleTiles.length > 0) {
     // Collect letters from non-frozen positions only; frozen tiles stay in place
     const shuffleablePositions: Pos[] = [];
@@ -848,7 +850,8 @@ function handleShuffleTiles(
       console.log(`Shuffle Q-U Validation: Fixed ${validation.violations} violations`);
     }
     
-    setBoard(validation.board);
+    resultBoard = validation.board;
+    setBoard(resultBoard);
     
     // Set all tiles as affected for visual effect
     const allTileKeys = new Set<string>();
@@ -865,6 +868,8 @@ function handleShuffleTiles(
     
     toast.success("Shuffle activated! All letters repositioned!");
   }
+  
+  return resultBoard;
 }
 
 function handleXFactorTiles(
@@ -875,9 +880,10 @@ function handleXFactorTiles(
   setBoard: (board: string[][]) => void,
   setSpecialTiles: (tiles: SpecialTile[][]) => void,
   setAffectedTiles: (tiles: Set<string>) => void
-): number {
+): { xChanged: number, board: string[][] } {
   const xFactorTiles = wordPath.filter(p => specialTiles[p.r][p.c].type === "xfactor");
   let xChanged = 0;
+  let resultBoard = currentBoard;
   
   if (xFactorTiles.length > 0) {
     const newBoard = currentBoard.map(row => [...row]);
@@ -921,7 +927,8 @@ function handleXFactorTiles(
       console.log(`X-Factor Q-U Validation: Fixed ${validation.violations} violations`);
     }
 
-    setBoard(validation.board);
+    resultBoard = validation.board;
+    setBoard(resultBoard);
     setSpecialTiles(newSpecialTiles);
     setAffectedTiles(changedTileKeys);
     xChanged = changedTileKeys.size;
@@ -933,7 +940,7 @@ function handleXFactorTiles(
     toast.info("X-Factor activated! Adjacent tiles transformed!");
   }
   
-  return xChanged;
+  return { xChanged, board: resultBoard };
 }
 
 // Apply Magnet spawn effect: replace orthogonal neighbors with random vowels
@@ -953,8 +960,8 @@ function applyMagnetSpawnEffect(
   for (const adj of orthogonal) {
     if (within(adj.r, adj.c, size) && specialTiles[adj.r][adj.c].type === null) {
       const currentLetter = newBoard[adj.r][adj.c];
-      if (!VOWELS.includes(currentLetter.toUpperCase())) {
-        newBoard[adj.r][adj.c] = VOWELS[Math.floor(Math.random() * VOWELS.length)];
+      if (!MAGNET_VOWELS.includes(currentLetter.toUpperCase())) {
+        newBoard[adj.r][adj.c] = MAGNET_VOWELS[Math.floor(Math.random() * MAGNET_VOWELS.length)];
       }
     }
   }
@@ -1026,7 +1033,7 @@ function handleBombBlast(
   setBoard: (board: string[][]) => void,
   setSpecialTiles: (tiles: SpecialTile[][]) => void,
   setAffectedTiles: (tiles: Set<string>) => void
-): SpecialTile[][] {
+): string[][] {
   const newBoard = board.map(row => [...row]);
   const newTiles = specialTiles.map(row => row.map(t => ({ ...t })));
   const changedKeys = new Set<string>();
@@ -1062,12 +1069,13 @@ function handleBombBlast(
 
   const validation = validateAndFixQUAdjacency(newBoard, size, letterCounts, undefined, true);
   setBoard(validation.board);
+  setSpecialTiles(newTiles);
   setAffectedTiles(changedKeys);
 
   setTimeout(() => setAffectedTiles(new Set()), 1500);
   toast.info("Bomb detonated! Area reset with new letters!");
   
-  return newTiles;
+  return validation.board;
 }
 
 function checkAndAwardAchievements(
@@ -2567,6 +2575,7 @@ function WordPathGame({
         const numTilesToPlace = Math.floor(Math.random() * 3) + 1;
         const tilesToPlace = Math.min(numTilesToPlace, emptyPositions.length);
         newWildPositions = [];
+        let currentBoard = board;
         for (let i = 0; i < tilesToPlace; i++) {
           const randomIndex = Math.floor(Math.random() * emptyPositions.length);
           const pos = emptyPositions.splice(randomIndex, 1)[0];
@@ -2583,8 +2592,8 @@ function WordPathGame({
             }
             // Apply spawn effects for enhanced tiles
             if (specialTile.type === "magnet") {
-              const magnetBoard = applyMagnetSpawnEffect(pos, board, updatedSpecialTiles, size);
-              setBoard(magnetBoard);
+              currentBoard = applyMagnetSpawnEffect(pos, currentBoard, updatedSpecialTiles, size);
+              setBoard(currentBoard);
             }
             if (specialTile.type === "freeze") {
               updatedSpecialTiles = applyFreezeSpawnEffect(pos, updatedSpecialTiles, size);
@@ -4090,24 +4099,25 @@ function WordPathGame({
       });
     }
 
-    // Handle X-Factor tiles first
-    const currentBoardForXFactor = board.map(row => [...row]);
-    const xChanged = handleXFactorTiles(
+    // Handle X-Factor tiles first and track board state through all effects
+    let trackedBoard = board.map(row => [...row]);
+    const xFactorResult = handleXFactorTiles(
       path, 
       specialTiles, 
-      currentBoardForXFactor, 
+      trackedBoard, 
       size, 
       setBoard, 
       setSpecialTiles, 
       setAffectedTiles
     );
+    const xChanged = xFactorResult.xChanged;
+    trackedBoard = xFactorResult.board;
 
-    // Handle shuffle tiles (use updated board if X-factor was triggered)
-    const currentBoard = xChanged > 0 ? board : currentBoardForXFactor;
-    handleShuffleTiles(
+    // Handle shuffle tiles (use updated board from X-factor)
+    trackedBoard = handleShuffleTiles(
       path, 
       specialTiles, 
-      currentBoard, 
+      trackedBoard, 
       size, 
       setBoard, 
       setAffectedTiles
@@ -4115,13 +4125,13 @@ function WordPathGame({
 
     // Handle Bomb tile blasts (after scoring, before clearing path tiles)
     const bombTilesInPath = path.filter(p => specialTiles[p.r][p.c].type === "bomb");
-    let newSpecialTiles = specialTiles.map(row => [...row]);
     if (bombTilesInPath.length > 0) {
-      const latestBoard = board.map(row => [...row]);
       for (const bombPos of bombTilesInPath) {
-        newSpecialTiles = handleBombBlast(bombPos, latestBoard, newSpecialTiles, size, setBoard, setSpecialTiles, setAffectedTiles);
+        trackedBoard = handleBombBlast(bombPos, trackedBoard, specialTiles, size, setBoard, setSpecialTiles, setAffectedTiles);
       }
     }
+
+    let newSpecialTiles = specialTiles.map(row => [...row]);
     path.forEach(p => {
       if (specialTiles[p.r][p.c].type !== null) {
         newSpecialTiles[p.r][p.c] = {
@@ -4132,9 +4142,10 @@ function WordPathGame({
 
     // Process Decay spread before expiry (enhanced powerups only, not daily)
     if (isEnhancedPowerupsEnabled() && settings.mode !== "daily") {
-      const decayResult = processDecaySpread(newSpecialTiles, board, size);
+      const decayResult = processDecaySpread(newSpecialTiles, trackedBoard, size);
       newSpecialTiles = decayResult.tiles;
-      setBoard(decayResult.board);
+      trackedBoard = decayResult.board;
+      setBoard(trackedBoard);
     }
 
     newSpecialTiles = expireSpecialTiles(newSpecialTiles);
@@ -4240,6 +4251,7 @@ function WordPathGame({
         const numTilesToPlace = Math.floor(Math.random() * 3) + 1;
         const tilesToPlace = Math.min(numTilesToPlace, emptyPositions.length);
         newWildPositions = [];
+        let currentBoard = board;
         for (let i = 0; i < tilesToPlace; i++) {
           const randomIndex = Math.floor(Math.random() * emptyPositions.length);
           const pos = emptyPositions.splice(randomIndex, 1)[0];
@@ -4256,8 +4268,8 @@ function WordPathGame({
             }
             // Apply spawn effects for enhanced tiles
             if (specialTile.type === "magnet") {
-              const magnetBoard = applyMagnetSpawnEffect(pos, board, updatedSpecialTiles, size);
-              setBoard(magnetBoard);
+              currentBoard = applyMagnetSpawnEffect(pos, currentBoard, updatedSpecialTiles, size);
+              setBoard(currentBoard);
             }
             if (specialTile.type === "freeze") {
               updatedSpecialTiles = applyFreezeSpawnEffect(pos, updatedSpecialTiles, size);

--- a/src/components/game/WordPathGame.tsx
+++ b/src/components/game/WordPathGame.tsx
@@ -5025,6 +5025,90 @@ function WordPathGame({
                 <div className="text-xs text-muted-foreground">
                   Special tiles appear after forming your first valid word and expire after a few turns.
                 </div>
+
+                {/* Enhanced Powerups tile descriptions (shown when toggle is active and not daily mode) */}
+                {isEnhancedPowerupsEnabled() && settings.mode !== "daily" && (
+                  <>
+                    <h4 className="text-xs font-semibold text-foreground mt-3">Enhanced Powerups</h4>
+                    <div className="grid grid-cols-2 gap-y-3 gap-x-2 sm:grid-cols-3">
+                      <div className="flex items-center gap-2">
+                        <div className="w-8 h-8 rounded bg-gradient-to-br from-cyan-300 to-blue-400 flex items-center justify-center text-white text-xs">
+                          ❄️
+                        </div>
+                        <div className="text-xs">
+                          <div className="font-medium">Freeze</div>
+                          <div className="text-muted-foreground">Locks neighbors in place</div>
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <div className="w-8 h-8 rounded bg-gradient-to-br from-yellow-300 to-green-500 flex items-center justify-center text-white text-xs">
+                          🦠
+                        </div>
+                        <div className="text-xs">
+                          <div className="font-medium">Decay</div>
+                          <div className="text-muted-foreground">Spreads, degrades letters</div>
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <div className="w-8 h-8 rounded bg-gradient-to-br from-gray-200 to-gray-400 flex items-center justify-center text-gray-800 text-xs">
+                          🪞
+                        </div>
+                        <div className="text-xs">
+                          <div className="font-medium">Mirror</div>
+                          <div className="text-muted-foreground">Copies previous letter</div>
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <div className="w-8 h-8 rounded bg-gradient-to-br from-red-400 to-gray-400 flex items-center justify-center text-white text-xs">
+                          🧲
+                        </div>
+                        <div className="text-xs">
+                          <div className="font-medium">Magnet</div>
+                          <div className="text-muted-foreground">Pulls vowels nearby</div>
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <div className="w-8 h-8 rounded bg-gradient-to-br from-red-600 to-gray-900 flex items-center justify-center text-white text-xs">
+                          💣
+                        </div>
+                        <div className="text-xs">
+                          <div className="font-medium">Bomb</div>
+                          <div className="text-muted-foreground">Blasts nearby tiles</div>
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <div className="w-8 h-8 rounded bg-gradient-to-br from-amber-500 to-amber-700 flex items-center justify-center text-white text-xs">
+                          ⛓️
+                        </div>
+                        <div className="text-xs">
+                          <div className="font-medium">Chain</div>
+                          <div className="text-muted-foreground">Bonus for long words</div>
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <div className="w-8 h-8 rounded bg-gradient-to-br from-white/60 to-gray-200/60 flex items-center justify-center text-gray-400 text-xs opacity-70">
+                          👻
+                        </div>
+                        <div className="text-xs">
+                          <div className="font-medium">Ghost</div>
+                          <div className="text-muted-foreground">Bridge tile, no letter</div>
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <div className="w-8 h-8 rounded bg-gradient-to-br from-yellow-400 to-yellow-600 flex items-center justify-center text-white text-xs">
+                          💰
+                        </div>
+                        <div className="text-xs">
+                          <div className="font-medium">Tax</div>
+                          <div className="text-muted-foreground">-30% word score</div>
+                        </div>
+                      </div>
+                    </div>
+                    <div className="text-xs text-muted-foreground">
+                      Enhanced tiles are enabled in Settings. They do not appear in Daily Challenge mode.
+                    </div>
+                  </>
+                )}
             </div>
             
             <div className="space-y-3">

--- a/src/components/game/WordPathGame.tsx
+++ b/src/components/game/WordPathGame.tsx
@@ -430,8 +430,11 @@ function computeScoreBreakdown(params: {
     const p = wordPath[i];
     const tile = specialTiles[p.r][p.c];
     if (tile.type === "ghost") continue; // Ghost contributes no letter
-    if (tile.type === "mirror" && actualLetters.length > 0) {
-      actualLetters.push(actualLetters[actualLetters.length - 1]); // Copy previous letter
+    if (tile.type === "mirror") {
+      if (actualLetters.length > 0) {
+        actualLetters.push(actualLetters[actualLetters.length - 1]); // Copy previous letter
+      }
+      // If no previous letter exists, mirror contributes nothing
     } else {
       actualLetters.push(board[p.r][p.c]);
     }

--- a/src/components/game/WordPathGame.tsx
+++ b/src/components/game/WordPathGame.tsx
@@ -1904,8 +1904,11 @@ function WordPathGame({
       const p = path[i];
       const tile = specialTiles[p.r][p.c];
       if (tile.type === "ghost") continue; // Ghost contributes no letter
-      if (tile.type === "mirror" && letters.length > 0) {
-        letters.push(letters[letters.length - 1]); // Copy previous letter
+      if (tile.type === "mirror") {
+        if (letters.length > 0) {
+          letters.push(letters[letters.length - 1]); // Copy previous letter
+        }
+        // If no previous letter exists, mirror contributes nothing
       } else {
         letters.push(board[p.r][p.c]);
       }
@@ -1950,8 +1953,11 @@ function WordPathGame({
         letters.push((wildTileInputs.get(wildKey) || '').toLowerCase());
       } else if (tile.type === "ghost") {
         continue; // Ghost contributes no letter
-      } else if (tile.type === "mirror" && letters.length > 0) {
-        letters.push(letters[letters.length - 1]); // Copy previous letter
+      } else if (tile.type === "mirror") {
+        if (letters.length > 0) {
+          letters.push(letters[letters.length - 1]); // Copy previous letter
+        }
+        // If no previous letter exists, mirror contributes nothing
       } else {
         letters.push(board[p.r][p.c]);
       }

--- a/src/components/game/WordPathGame.tsx
+++ b/src/components/game/WordPathGame.tsx
@@ -2646,7 +2646,9 @@ function WordPathGame({
             settings.mode === "endless" ? endlessDifficulty : 1
           );
           if (specialTile.type !== null) {
-            updatedSpecialTiles[pos.r][pos.c] = specialTile;
+            // Preserve frozen flag if it exists
+            const existingFrozen = updatedSpecialTiles[pos.r][pos.c].frozen;
+            updatedSpecialTiles[pos.r][pos.c] = { ...specialTile, frozen: existingFrozen || specialTile.frozen };
             // Track newly spawned Wild tiles
             if (specialTile.type === "wild") {
               newWildPositions.push(keyOf(pos));
@@ -4331,7 +4333,9 @@ function WordPathGame({
             settings.mode === "endless" ? endlessDifficulty : 1
           );
           if (specialTile.type !== null) {
-            updatedSpecialTiles[pos.r][pos.c] = specialTile;
+            // Preserve frozen flag if it exists
+            const existingFrozen = updatedSpecialTiles[pos.r][pos.c].frozen;
+            updatedSpecialTiles[pos.r][pos.c] = { ...specialTile, frozen: existingFrozen || specialTile.frozen };
             // Track newly spawned Wild tiles
             if (specialTile.type === "wild") {
               newWildPositions.push(keyOf(pos));

--- a/src/components/game/WordPathGame.tsx
+++ b/src/components/game/WordPathGame.tsx
@@ -3697,7 +3697,12 @@ function WordPathGame({
     }
   }
   function tryAddToPath(pos: Pos) {
-    if (path.length && !neighbors(path[path.length - 1], pos)) return;
+    // Ghost tiles can bridge non-adjacent tiles - check if last tile is ghost or current tile is ghost
+    const lastTile = path.length > 0 ? specialTiles[path[path.length - 1].r][path[path.length - 1].c] : null;
+    const currentTile = specialTiles[pos.r][pos.c];
+    const canSkipAdjacency = lastTile?.type === "ghost" || currentTile.type === "ghost";
+    
+    if (path.length && !canSkipAdjacency && !neighbors(path[path.length - 1], pos)) return;
     const k = keyOf(pos);
     if (path.find(p => p.r === pos.r && p.c === pos.c)) return;
 
@@ -3888,8 +3893,13 @@ function WordPathGame({
         // If tapping a tile already in path, remove it and all tiles after it
         setPath(path.slice(0, existingIndex));
       } else {
-        // Try to add to path (must be adjacent to last tile)
-        if (path.length && neighbors(path[path.length - 1], pos)) {
+        // Try to add to path (must be adjacent to last tile, unless ghost tile is involved)
+        const lastTile = specialTiles[path[path.length - 1].r][path[path.length - 1].c];
+        const currentTile = specialTiles[pos.r][pos.c];
+        const canSkipAdjacency = lastTile.type === "ghost" || currentTile.type === "ghost";
+        const isAdjacent = neighbors(path[path.length - 1], pos);
+        
+        if (path.length && (isAdjacent || canSkipAdjacency)) {
           // Check if this is a stone tile and it's blocked
           const specialTile = specialTiles[pos.r][pos.c];
           if (specialTile.type === "stone") {
@@ -3898,7 +3908,7 @@ function WordPathGame({
           }
           setPath([...path, pos]);
         } else if (path.length) {
-          // Not adjacent - show warning
+          // Not adjacent and no ghost - show warning
           toast.warning("Must select adjacent tiles");
         }
       }

--- a/src/components/settings/GameSettings.tsx
+++ b/src/components/settings/GameSettings.tsx
@@ -16,6 +16,14 @@ export function GameSettings() {
   const [floatingTiles, setFloatingTiles] = useState(() => {
     return localStorage.getItem('lexichain-floating-tiles') !== 'false';
   });
+  const [enhancedPowerups, setEnhancedPowerups] = useState(() => {
+    return localStorage.getItem('lexichain-enhanced-powerups') === 'true';
+  });
+
+  const handleEnhancedPowerupsToggle = (checked: boolean) => {
+    setEnhancedPowerups(checked);
+    localStorage.setItem('lexichain-enhanced-powerups', checked ? 'true' : 'false');
+  };
 
   const handleFloatingTilesToggle = (checked: boolean) => {
     setFloatingTiles(checked);
@@ -91,7 +99,19 @@ export function GameSettings() {
 
                 <Separator />
 
-                
+                <div className="flex items-center justify-between">
+                  <div>
+                    <label className="text-sm font-medium">Enhanced Powerups</label>
+                    <p className="text-xs text-muted-foreground">
+                      Adds 8 new tile types: Freeze, Decay, Mirror, Magnet, Bomb, Chain, Ghost, and Tax. Does not apply to Daily Challenge.
+                    </p>
+                  </div>
+                  <Switch checked={enhancedPowerups} onCheckedChange={handleEnhancedPowerupsToggle} />
+                </div>
+
+                <Separator />
+
+
               </div>
             </div>
           </TabsContent>

--- a/src/components/tutorial/TutorialSteps.tsx
+++ b/src/components/tutorial/TutorialSteps.tsx
@@ -77,6 +77,16 @@ export const TUTORIAL_STEPS: TutorialStep[] = [
     skipable: true
   },
   {
+    id: 'special_tiles',
+    title: 'Special Tiles',
+    description: 'Special tiles appear on the board as you play. Stone blocks paths, Wild acts as any letter, Multiplier boosts scores, X-Factor changes nearby letters, and Shuffle rearranges the board. Enable "Enhanced Powerups" in Settings for 8 more tile types including Mirror, Ghost, Chain, Tax, and more!',
+    target: '[data-tutorial="game-board"]',
+    position: 'bottom',
+    action: 'wait',
+    icon: <Star className="h-5 w-5 text-primary" />,
+    skipable: true
+  },
+  {
     id: 'game_modes',
     title: 'Game Modes',
     description: 'Try different game modes! Daily Challenge offers a new puzzle each day, Classic mode has no time limits, and Practice mode helps you improve your skills.',

--- a/src/components/ui/special-tile-preview.tsx
+++ b/src/components/ui/special-tile-preview.tsx
@@ -50,6 +50,30 @@ function TileIcon({ tile }: { tile: SpecialTile }) {
     } else if (tile.type === "shuffle") {
       baseClasses +=
         "bg-gradient-to-br from-red-200 to-red-300 text-red-800 shadow-[0_0_15px_rgba(239,68,68,0.3)]";
+    } else if (tile.type === "freeze") {
+      baseClasses +=
+        "bg-gradient-to-br from-cyan-300 to-blue-400 text-white shadow-[0_0_20px_rgba(34,211,238,0.5)]";
+    } else if (tile.type === "decay") {
+      baseClasses +=
+        "bg-gradient-to-br from-yellow-300 to-green-500 text-white shadow-[0_0_15px_rgba(132,204,22,0.4)]";
+    } else if (tile.type === "mirror") {
+      baseClasses +=
+        "bg-gradient-to-br from-gray-200 to-gray-400 text-gray-800 shadow-[0_0_20px_rgba(156,163,175,0.5)]";
+    } else if (tile.type === "magnet") {
+      baseClasses +=
+        "bg-gradient-to-br from-red-400 to-gray-400 text-white shadow-[0_0_15px_rgba(248,113,113,0.4)]";
+    } else if (tile.type === "bomb") {
+      baseClasses +=
+        "bg-gradient-to-br from-red-600 to-gray-900 text-white shadow-[0_0_20px_rgba(220,38,38,0.5)]";
+    } else if (tile.type === "chain") {
+      baseClasses +=
+        "bg-gradient-to-br from-amber-500 to-amber-700 text-white shadow-[0_0_15px_rgba(217,119,6,0.4)]";
+    } else if (tile.type === "ghost") {
+      baseClasses +=
+        "bg-gradient-to-br from-white/60 to-gray-200/60 text-gray-400 shadow-[0_0_15px_rgba(255,255,255,0.3)] opacity-70";
+    } else if (tile.type === "tax") {
+      baseClasses +=
+        "bg-gradient-to-br from-yellow-400 to-yellow-600 text-white shadow-[0_0_15px_rgba(234,179,8,0.4)]";
     }
 
     return baseClasses;
@@ -96,6 +120,15 @@ function TileIcon({ tile }: { tile: SpecialTile }) {
           </svg>
         </div>
       )}
+
+      {tile.type === "freeze" && <div className="text-2xl opacity-80">❄️</div>}
+      {tile.type === "decay" && <div className="text-2xl opacity-80">🦠</div>}
+      {tile.type === "mirror" && <div className="text-2xl opacity-80">🪞</div>}
+      {tile.type === "magnet" && <div className="text-2xl opacity-80">🧲</div>}
+      {tile.type === "bomb" && <div className="text-2xl opacity-80">💣</div>}
+      {tile.type === "chain" && <div className="text-2xl opacity-80">⛓️</div>}
+      {tile.type === "ghost" && <div className="text-2xl opacity-80">👻</div>}
+      {tile.type === "tax" && <div className="text-2xl opacity-80">💰</div>}
 
       {/* Expiry turns indicator */}
       {tile.expiryTurns !== undefined && (

--- a/src/utils/specialTilePreview.ts
+++ b/src/utils/specialTilePreview.ts
@@ -3,12 +3,14 @@
  * in Daily Challenge mode.
  */
 
-export type SpecialTileType = "stone" | "wild" | "xfactor" | "multiplier" | "shuffle";
+export type SpecialTileType = "stone" | "wild" | "xfactor" | "multiplier" | "shuffle"
+  | "freeze" | "decay" | "mirror" | "magnet" | "bomb" | "chain" | "ghost" | "tax";
 
 export interface SpecialTile {
   type: SpecialTileType | null;
   value?: number; // For multipliers (2x, 3x, 4x)
   expiryTurns?: number; // Number of turns until expiry
+  frozen?: boolean; // Whether this tile is frozen (protected by adjacent Freeze tile)
 }
 
 const SPECIAL_TILE_RARITIES = {


### PR DESCRIPTION
Proposes Freeze, Decay, Mirror, Magnet, Bomb, Chain, Ghost, and Tax
tiles with unique mechanics that complement the existing Stone, Wild,
XFactor, Multiplier, and Shuffle tiles. Includes rarity budgets,
visual specs, and implementation notes.

https://claude.ai/code/session_01WD2YFmJRnw3KzPm9NSkRkp

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core word assembly, scoring, and board-mutation logic; bugs here could break validation, scoring fairness, or tile state updates across modes. Changes are gated behind an `Enhanced Powerups` toggle (and disabled for Daily), which limits blast radius but still adds complex interactions.
> 
> **Overview**
> Adds an `Enhanced Powerups` mode (toggle stored in `localStorage`, excluded from Daily) that introduces 8 new special tile types: `freeze`, `decay`, `mirror`, `magnet`, `bomb`, `chain`, `ghost`, and `tax`, plus a design doc describing their intended mechanics and balance.
> 
> Implements the new tile behaviors in gameplay: Ghost/Mirror alter how the word is assembled and how rarity is computed, Ghost can bridge a single non-adjacent step (max 1 per word), Chain adds an additive long-word bonus, Tax applies a post-multiplier score penalty, Bomb resets a local area after scoring, Magnet mutates adjacent letters on spawn, Decay can spread during turn ticks, and Freeze marks adjacent tiles as `frozen` to block Shuffle/X-Factor/Bomb/Decay mutations.
> 
> Updates UI/UX to surface the feature: settings toggle, tutorial step, in-game tile legend, board rendering/styles/icons (including frozen indicator), and expands special-tile preview/type definitions to include the new tiles.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58c9deae589c7a706a0ba7d52ef11b407632bec5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->