### PR TITLE
Add Daily Challenge 5x5 game mode with dedicated state management

### DIFF
--- a/src/components/auth/AuthForm.tsx
+++ b/src/components/auth/AuthForm.tsx
@@ -5,6 +5,7 @@ import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { useToast } from "@/hooks/use-toast";
 import { supabase } from "@/integrations/supabase/client";
+import { FloatingTiles } from "@/components/effects/FloatingTiles";
 
 interface AuthFormProps {
   onBackToTitle: () => void;
@@ -90,8 +91,9 @@ const AuthForm = ({ onBackToTitle, initialMode = "signup" }: AuthFormProps) => {
   };
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-background to-muted p-4">
-      <div className="w-full max-w-md">
+    <div className="relative overflow-hidden min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-background to-muted p-4">
+      <FloatingTiles />
+      <div className="relative z-10 w-full max-w-md">
         <Card>
           <CardHeader className="text-center">
             <CardTitle className="text-2xl font-bold">

--- a/src/components/game/AdvancedGameModes.tsx
+++ b/src/components/game/AdvancedGameModes.tsx
@@ -8,6 +8,7 @@ import { useSound } from '@/components/effects';
 import { XP_REQUIREMENTS, calculateLevel } from '@/lib/progression';
 import { useUnlockedModes } from '@/hooks/useUnlockedModes';
 import type { User } from '@supabase/supabase-js';
+import { FloatingTiles } from '@/components/effects/FloatingTiles';
 export type AdvancedGameMode = 'classic' | 'time_attack' | 'endless' | 'puzzle' | 'survival' | 'zen' | 'chaos' | 'mini_marathon' | 'weekly_gauntlet' | 'prestige_endless';
 interface AdvancedModeConfig {
   id: AdvancedGameMode;
@@ -232,16 +233,7 @@ export function AdvancedGameModes({
     }
   };
   return <div className="min-h-screen bg-gradient-to-br from-background via-muted/30 to-background p-6 relative overflow-hidden">
-      {/* Animated background decoration */}
-      <div className="absolute inset-0 overflow-hidden pointer-events-none">
-        <div className="absolute top-1/4 right-0 w-96 h-96 bg-brand-500/5 rounded-full blur-3xl animate-pulse" style={{
-        animationDuration: '5s'
-      }}></div>
-        <div className="absolute bottom-1/4 left-0 w-96 h-96 bg-brand-400/5 rounded-full blur-3xl animate-pulse" style={{
-        animationDuration: '7s',
-        animationDelay: '1s'
-      }}></div>
-      </div>
+      <FloatingTiles />
 
       <div className="container mx-auto max-w-6xl relative z-10">
         {/* Header */}

--- a/src/components/game/MiniMarathon.tsx
+++ b/src/components/game/MiniMarathon.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Flag, Clock, Zap, Trophy, ArrowLeft } from 'lucide-react';
+import { FloatingTiles } from '@/components/effects/FloatingTiles';
 
 interface MiniMarathonProps {
   onBack: () => void;
@@ -12,8 +13,9 @@ export function MiniMarathon({ onBack }: MiniMarathonProps) {
   const today = new Date().toISOString().split('T')[0];
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-background via-muted/30 to-background p-6">
-      <div className="container mx-auto max-w-4xl">
+    <div className="min-h-screen bg-gradient-to-br from-background via-muted/30 to-background p-6 relative overflow-hidden">
+      <FloatingTiles />
+      <div className="container mx-auto max-w-4xl relative z-10">
         {/* Header */}
         <div className="flex items-center gap-4 mb-8">
           <Button

--- a/src/components/game/PrestigeEndless.tsx
+++ b/src/components/game/PrestigeEndless.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { TrendingUp, Infinity, Sparkles, Trophy, Award, ArrowLeft, Zap } from 'lucide-react';
+import { FloatingTiles } from '@/components/effects/FloatingTiles';
 
 interface PrestigeEndlessProps {
   onBack: () => void;
@@ -19,8 +20,9 @@ export function PrestigeEndless({ onBack }: PrestigeEndlessProps) {
   ];
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-background via-muted/30 to-background p-6">
-      <div className="container mx-auto max-w-6xl">
+    <div className="min-h-screen bg-gradient-to-br from-background via-muted/30 to-background p-6 relative overflow-hidden">
+      <FloatingTiles />
+      <div className="container mx-auto max-w-6xl relative z-10">
         {/* Header */}
         <div className="flex items-center gap-4 mb-8">
           <Button

--- a/src/components/game/PuzzleSelector.tsx
+++ b/src/components/game/PuzzleSelector.tsx
@@ -6,6 +6,7 @@ import { PUZZLE_BOARDS, PuzzleBoard } from "@/lib/puzzleBoards";
 import { Check, Lock, Trophy, Lightbulb } from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";
 import type { User } from "@supabase/supabase-js";
+import { FloatingTiles } from "@/components/effects/FloatingTiles";
 
 interface PuzzleSelectorProps {
   onPuzzleSelect: (puzzleId: string) => void;
@@ -65,11 +66,7 @@ export default function PuzzleSelector({ onPuzzleSelect, onBack, user }: PuzzleS
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-background via-muted/30 to-background p-4 relative overflow-hidden">
-      {/* Animated background decoration */}
-      <div className="absolute inset-0 overflow-hidden pointer-events-none">
-        <div className="absolute top-1/4 left-0 w-96 h-96 bg-brand-500/5 rounded-full blur-3xl animate-pulse" style={{ animationDuration: '5s' }}></div>
-        <div className="absolute bottom-1/4 right-0 w-96 h-96 bg-brand-400/5 rounded-full blur-3xl animate-pulse" style={{ animationDuration: '7s', animationDelay: '1s' }}></div>
-      </div>
+      <FloatingTiles />
 
       <div className="container mx-auto max-w-6xl relative z-10">
         <div className="mb-6 flex items-center justify-between animate-in fade-in slide-in-from-top duration-500">

--- a/src/components/game/WeeklyGauntlet.tsx
+++ b/src/components/game/WeeklyGauntlet.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Badge } from '@/components/ui/badge';
 import { Sword, Calendar, Trophy, Star, ArrowLeft, CheckCircle } from 'lucide-react';
 import { getWeekIdentifier } from '@/hooks/useWeeklyGauntletState';
+import { FloatingTiles } from '@/components/effects/FloatingTiles';
 
 interface WeeklyGauntletProps {
   onBack: () => void;
@@ -23,8 +24,9 @@ export function WeeklyGauntlet({ onBack }: WeeklyGauntletProps) {
   ];
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-background via-muted/30 to-background p-6">
-      <div className="container mx-auto max-w-6xl">
+    <div className="min-h-screen bg-gradient-to-br from-background via-muted/30 to-background p-6 relative overflow-hidden">
+      <FloatingTiles />
+      <div className="container mx-auto max-w-6xl relative z-10">
         {/* Header */}
         <div className="flex items-center gap-4 mb-8">
           <Button

--- a/src/components/game/WordPathGame.tsx
+++ b/src/components/game/WordPathGame.tsx
@@ -87,7 +87,7 @@ type SpecialTile = {
   expiryTurns?: number;
   frozen?: boolean;
 };
-type GameMode = "classic" | "target" | "daily" | "practice" | "blitz" | "time_attack" | "endless" | "puzzle" | "survival" | "zen" | "chaos";
+type GameMode = "classic" | "target" | "daily" | "daily_5x5" | "practice" | "blitz" | "time_attack" | "endless" | "puzzle" | "survival" | "zen" | "chaos";
 type GameSettings = {
   scoreThreshold: number;
   mode: GameMode;
@@ -386,7 +386,7 @@ function computeScoreBreakdown(params: {
   specialTiles: SpecialTile[][];
   lastWordTiles: Set<string>;
   streak: number;
-  mode: "classic" | "daily" | "target" | "practice" | "blitz" | "time_attack" | "endless" | "puzzle" | "survival" | "zen" | "chaos";
+  mode: "classic" | "daily" | "daily_5x5" | "target" | "practice" | "blitz" | "time_attack" | "endless" | "puzzle" | "survival" | "zen" | "chaos";
   blitzMultiplier: number;
   timeAttackSpeedMultiplier?: number;
   activeEffects: Array<{
@@ -1175,7 +1175,7 @@ function WordPathGame({
 }: {
   onBackToTitle?: () => void;
   onBackToAdvancedModes?: () => void;
-  initialMode?: "classic" | "daily" | "practice" | "blitz" | "time_attack" | "endless" | "puzzle" | "survival" | "zen" | "chaos";
+  initialMode?: "classic" | "daily" | "daily_5x5" | "practice" | "blitz" | "time_attack" | "endless" | "puzzle" | "survival" | "zen" | "chaos";
   initialPuzzleId?: string;
 }) {
   const [user, setUser] = useState<User | null>(null);
@@ -1184,6 +1184,7 @@ function WordPathGame({
     updateGoalProgress
   } = useGoals(user);
   const dailyChallengeState = useDailyChallengeState(getDailySeed());
+  const dailyChallengeState5x5 = useDailyChallengeState(getDailySeed() + "-5x5");
   const {
     inventory: consumableInventory,
     activeEffects,
@@ -1356,6 +1357,9 @@ function WordPathGame({
     if (initialMode === "daily") {
       setDailyChallengeInitialized(true);
       startDailyChallenge().catch(console.error);
+    } else if (initialMode === "daily_5x5") {
+      setDailyChallengeInitialized(true);
+      startDaily5x5Challenge().catch(console.error);
     } else if (initialMode === "practice") {
       setDailyChallengeInitialized(true);
       startNewPracticeGame().catch(console.error);
@@ -1491,7 +1495,7 @@ function WordPathGame({
 
   // Save standard game result and update goals when game ends
   const saveGameResult = useCallback(async () => {
-    if (settings.mode === "daily" || settings.mode === "practice" || !gameOver) return;
+    if (settings.mode === "daily" || settings.mode === "daily_5x5" || settings.mode === "practice" || !gameOver) return;
     if (!user) {
       console.log("Cannot save XP - user not logged in");
       return;
@@ -1642,6 +1646,8 @@ function WordPathGame({
     if (gameOver) {
       if (settings.mode === "daily") {
         saveDailyChallengeResult();
+      } else if (settings.mode === "daily_5x5") {
+        // 5x5 daily state is auto-saved via the periodic save mechanism
       } else {
         saveGameResult();
       }
@@ -1650,7 +1656,7 @@ function WordPathGame({
 
   // Auto-save game result when game ends (for standard modes)
   useEffect(() => {
-    if (gameOver && user && settings.mode !== "daily" && settings.mode !== "practice") {
+    if (gameOver && user && settings.mode !== "daily" && settings.mode !== "daily_5x5" && settings.mode !== "practice") {
       saveGameResult();
     }
   }, [gameOver, user, settings.mode, saveGameResult]);
@@ -1676,6 +1682,29 @@ function WordPathGame({
         discoverableCount
       };
       await dailyChallengeState.saveState(gameState, immediate);
+    }
+  };
+
+  // Save 5x5 daily challenge state
+  const saveDaily5x5State = async (initialBoardToSave?: string[][], immediate = false) => {
+    if (settings.mode === "daily_5x5") {
+      const gameState = {
+        board,
+        initialBoard: initialBoardToSave || board,
+        specialTiles,
+        usedWords,
+        score,
+        streak,
+        movesUsed,
+        unlocked: Array.from(unlocked),
+        gameOver,
+        finalGrade,
+        lastWordTiles: Array.from(lastWordTiles),
+        seed: getDailySeed() + "-5x5",
+        benchmarks,
+        discoverableCount
+      };
+      await dailyChallengeState5x5.saveState(gameState, immediate);
     }
   };
   const loadDailyState = async () => {
@@ -1726,8 +1755,10 @@ function WordPathGame({
   const saveGameState = useCallback(() => {
     if (settings.mode === "daily" && !isInitializing && board && board.length > 0) {
       saveDailyState();
+    } else if (settings.mode === "daily_5x5" && !isInitializing && board && board.length > 0) {
+      saveDaily5x5State();
     }
-  }, [settings.mode, isInitializing, board, saveDailyState]);
+  }, [settings.mode, isInitializing, board, saveDailyState, saveDaily5x5State]);
   
   // Puzzle mode helpers
   const savePuzzleCompletion = async (lastWord: string) => {
@@ -1879,7 +1910,7 @@ function WordPathGame({
 
   // Dictionary-ready benchmark calculation for daily challenges
   useEffect(() => {
-    if (dict && sorted && settings.mode === "daily" && board && !benchmarks && !isGenerating) {
+    if (dict && sorted && (settings.mode === "daily" || settings.mode === "daily_5x5") && board && !benchmarks && !isGenerating) {
       console.log("📊 Dictionary loaded, recalculating benchmarks for resumed daily challenge...");
       setIsGenerating(true);
       try {
@@ -2001,7 +2032,7 @@ function WordPathGame({
     }
 
     // Check daily challenge move limit
-    if (settings.mode === "daily" && movesUsed >= settings.dailyMovesLimit) {
+    if ((settings.mode === "daily" || settings.mode === "daily_5x5") && movesUsed >= settings.dailyMovesLimit) {
       toast.error("Daily move limit reached!");
       return;
     }
@@ -2089,7 +2120,7 @@ function WordPathGame({
     }
 
     // Check daily challenge move limit
-    if (settings.mode === "daily" && movesUsed >= settings.dailyMovesLimit) {
+    if ((settings.mode === "daily" || settings.mode === "daily_5x5") && movesUsed >= settings.dailyMovesLimit) {
       toast.error("Daily move limit reached!");
       return;
     }
@@ -2166,7 +2197,7 @@ function WordPathGame({
       setSpecialTiles(newSpecialTiles);
     }
     // Increment moves for daily challenge
-    if (settings.mode === "daily") {
+    if (settings.mode === "daily" || settings.mode === "daily_5x5") {
       setMovesUsed(prev => prev + 1);
     }
     
@@ -2223,7 +2254,7 @@ function WordPathGame({
     });
 
     // Process Decay spread before expiry (enhanced powerups only, not daily)
-    if (isEnhancedPowerupsEnabled() && settings.mode !== "daily") {
+    if (isEnhancedPowerupsEnabled() && settings.mode !== "daily" && settings.mode !== "daily_5x5") {
       const decayResult = processDecaySpread(newSpecialTiles, trackedBoard, size);
       newSpecialTiles = decayResult.tiles;
       trackedBoard = decayResult.board;
@@ -2604,14 +2635,15 @@ function WordPathGame({
       let updatedSpecialTiles: SpecialTile[][];
       let newWildPositions: string[];
 
-      if (settings.mode === "daily") {
+      if (settings.mode === "daily" || settings.mode === "daily_5x5") {
         // Use seeded special tiles for daily challenge - all players get same tiles
+        const dailySeedForMode = settings.mode === "daily_5x5" ? getDailySeed() + "-5x5" : getDailySeed();
         const result = introduceSeededSpecialTiles(
           newSpecialTiles,
           usedWords.length + 1, // +1 because we just completed a word
           score,
           size,
-          getDailySeed()
+          dailySeedForMode
         );
         updatedSpecialTiles = result.tiles;
         newWildPositions = result.newWildPositions;
@@ -2686,7 +2718,7 @@ function WordPathGame({
     setTimeout(() => {
       if (sorted && dict) {
         // Check if daily challenge is out of moves
-        const dailyMovesExceeded = settings.mode === "daily" && movesUsed + 1 >= settings.dailyMovesLimit;
+        const dailyMovesExceeded = (settings.mode === "daily" || settings.mode === "daily_5x5") && movesUsed + 1 >= settings.dailyMovesLimit;
         const any = hasAnyValidMove(newBoard, lastWordTiles.size ? lastWordTiles : new Set(wordPath.map(keyOf)), dict, sorted, new Set(usedWords.map(entry => entry.word)));
         if (!any || dailyMovesExceeded) {
           if (benchmarks) {
@@ -2864,7 +2896,7 @@ function WordPathGame({
     let cumulative = 0;
 
     // Use enhanced rarities if toggle is on and mode is not daily
-    const useEnhanced = isEnhancedPowerupsEnabled() && gameMode !== "daily";
+    const useEnhanced = isEnhancedPowerupsEnabled() && gameMode !== "daily" && gameMode !== "daily_5x5";
     const baseRarities: Record<string, number> = useEnhanced ? { ...ENHANCED_TILE_RARITIES } : { ...SPECIAL_TILE_RARITIES };
 
     // Progressive stone spawning for classic mode
@@ -3349,6 +3381,129 @@ function WordPathGame({
       await saveDailyState(newBoard, true);
     }
   }
+
+  async function startDaily5x5Challenge() {
+    const size5x5 = 5;
+    const dailySeed5x5 = getDailySeed() + "-5x5";
+    const config = DIFFICULTY_CONFIG["medium"];
+
+    // Try to load existing 5x5 daily state first
+    const savedState5x5 = await dailyChallengeState5x5.loadState();
+    if (savedState5x5 && savedState5x5.board && savedState5x5.initialBoard) {
+      setBoard(savedState5x5.board);
+      setSpecialTiles(savedState5x5.specialTiles);
+      setUsedWords(savedState5x5.usedWords);
+      setScore(savedState5x5.score);
+      setStreak(savedState5x5.streak);
+      setMovesUsed(savedState5x5.movesUsed);
+      setUnlocked(new Set(savedState5x5.unlocked));
+      setGameOver(savedState5x5.gameOver);
+      setFinalGrade(savedState5x5.finalGrade);
+      setLastWordTiles(new Set(savedState5x5.lastWordTiles || []));
+      if (savedState5x5.benchmarks && savedState5x5.discoverableCount !== undefined) {
+        setBenchmarks(savedState5x5.benchmarks);
+        setDiscoverableCount(savedState5x5.discoverableCount);
+      }
+      setSettings(prev => ({
+        ...prev,
+        difficulty: "medium",
+        gridSize: size5x5,
+        mode: "daily_5x5",
+        dailyMovesLimit: getDailyMovesLimit()
+      }));
+      setSize(size5x5);
+      toast.success("5x5 Daily Challenge resumed!");
+      return;
+    }
+
+    // Start fresh 5x5 daily challenge
+    setSettings(prev => ({
+      ...prev,
+      difficulty: "medium",
+      gridSize: size5x5,
+      mode: "daily_5x5",
+      dailyMovesLimit: getDailyMovesLimit()
+    }));
+    setSize(size5x5);
+    const newBoard5x5 = makeBoard(size5x5, dailySeed5x5);
+
+    // Reset all game state
+    setPath([]);
+    setDragging(false);
+    setUsedWords([]);
+    setLastWordTiles(new Set());
+    setScore(0);
+    setStreak(0);
+    setMovesUsed(0);
+    setUnlocked(new Set());
+    setGameOver(false);
+    setFinalGrade("None");
+    setSpecialTiles(createEmptySpecialTilesGrid(size5x5));
+    setBoard(newBoard5x5);
+
+    if (dict && sorted) {
+      setIsGenerating(true);
+      try {
+        const probe = probeGrid(newBoard5x5, dict, sorted, config.minWords, MAX_DFS_NODES, true);
+        let bms: Benchmarks;
+        try {
+          if (probe.analysis && user) {
+            bms = await computeDynamicBenchmarks(dailySeed5x5, probe.words.size, config.minWords, probe.analysis, supabase);
+          } else if (probe.analysis) {
+            bms = computeBoardSpecificBenchmarks(probe.words.size, config.minWords, probe.analysis);
+          } else {
+            bms = computeBenchmarksFromWordCount(probe.words.size, config.minWords);
+          }
+        } catch (error) {
+          console.error('Error computing 5x5 benchmarks, falling back to static:', error);
+          bms = probe.analysis ? computeBoardSpecificBenchmarks(probe.words.size, config.minWords, probe.analysis) : computeBenchmarksFromWordCount(probe.words.size, config.minWords);
+        }
+        setBenchmarks(bms);
+        setDiscoverableCount(probe.words.size);
+        toast.success(`5x5 Daily Challenge ready! ${getDailyMovesLimit()} moves to make your best score.`);
+
+        // Save initial state
+        const initialGameState = {
+          board: newBoard5x5,
+          initialBoard: newBoard5x5,
+          specialTiles: createEmptySpecialTilesGrid(size5x5),
+          usedWords: [],
+          score: 0,
+          streak: 0,
+          movesUsed: 0,
+          unlocked: [],
+          gameOver: false,
+          finalGrade: "None" as const,
+          lastWordTiles: [],
+          seed: dailySeed5x5,
+          benchmarks: bms,
+          discoverableCount: probe.words.size
+        };
+        await dailyChallengeState5x5.saveState(initialGameState, true);
+      } finally {
+        setIsGenerating(false);
+      }
+    } else {
+      setBenchmarks(null);
+      setDiscoverableCount(0);
+      const initialGameState = {
+        board: newBoard5x5,
+        initialBoard: newBoard5x5,
+        specialTiles: createEmptySpecialTilesGrid(size5x5),
+        usedWords: [],
+        score: 0,
+        streak: 0,
+        movesUsed: 0,
+        unlocked: [],
+        gameOver: false,
+        finalGrade: "None" as const,
+        lastWordTiles: [],
+        seed: dailySeed5x5
+      };
+      await dailyChallengeState5x5.saveState(initialGameState, true);
+    }
+  }
+
   async function resetDailyChallenge() {
     // Try to get the saved initial board from the current state
     const savedState = await dailyChallengeState.loadState();
@@ -3991,7 +4146,7 @@ function WordPathGame({
     }
 
     // Check daily challenge move limit
-    if (settings.mode === "daily" && movesUsed >= settings.dailyMovesLimit) {
+    if ((settings.mode === "daily" || settings.mode === "daily_5x5") && movesUsed >= settings.dailyMovesLimit) {
       toast.error("Daily move limit reached!");
       return clearPath();
     }
@@ -4151,7 +4306,7 @@ function WordPathGame({
     const multiplier = breakdown.multipliers.combinedApplied;
 
     // Increment moves for daily challenge, puzzle mode, and chaos mode
-    if (settings.mode === "daily" || settings.mode === "puzzle" || (settings.mode === "chaos" && chaosStarted)) {
+    if (settings.mode === "daily" || settings.mode === "daily_5x5" || settings.mode === "puzzle" || (settings.mode === "chaos" && chaosStarted)) {
       setMovesUsed(prev => prev + 1);
     }
     
@@ -4213,7 +4368,7 @@ function WordPathGame({
     });
 
     // Process Decay spread before expiry (enhanced powerups only, not daily)
-    if (isEnhancedPowerupsEnabled() && settings.mode !== "daily") {
+    if (isEnhancedPowerupsEnabled() && settings.mode !== "daily" && settings.mode !== "daily_5x5") {
       const decayResult = processDecaySpread(newSpecialTiles, trackedBoard, size);
       newSpecialTiles = decayResult.tiles;
       trackedBoard = decayResult.board;
@@ -4291,14 +4446,15 @@ function WordPathGame({
       let updatedSpecialTiles: SpecialTile[][];
       let newWildPositions: string[];
 
-      if (settings.mode === "daily") {
+      if (settings.mode === "daily" || settings.mode === "daily_5x5") {
         // Use seeded special tiles for daily challenge - all players get same tiles
+        const dailySeedForMode = settings.mode === "daily_5x5" ? getDailySeed() + "-5x5" : getDailySeed();
         const result = introduceSeededSpecialTiles(
           newSpecialTiles,
           usedWords.length + 1, // +1 because we just completed a word
           score,
           size,
-          getDailySeed()
+          dailySeedForMode
         );
         updatedSpecialTiles = result.tiles;
         newWildPositions = result.newWildPositions;
@@ -4585,7 +4741,7 @@ function WordPathGame({
     setTimeout(() => {
       if (sorted && dict) {
         // Check if daily challenge is out of moves
-        const dailyMovesExceeded = settings.mode === "daily" && movesUsed + 1 >= settings.dailyMovesLimit;
+        const dailyMovesExceeded = (settings.mode === "daily" || settings.mode === "daily_5x5") && movesUsed + 1 >= settings.dailyMovesLimit;
         // Check if puzzle mode is out of moves
         const puzzleMovesExceeded = puzzleMode && puzzleMovesRemaining <= 1;
         const any = hasAnyValidMove(board, lastWordTiles.size ? lastWordTiles : new Set(path.map(keyOf)), dict, sorted, new Set(usedWords.map(entry => entry.word)));
@@ -5356,10 +5512,10 @@ function WordPathGame({
             gameOver,
             isGenerating
           }} disabled={gameOver || isGenerating} />
-              {settings.mode === "daily" && !gameOver && usedWords.length >= 1 && (() => {
+              {(settings.mode === "daily" || settings.mode === "daily_5x5") && !gameOver && usedWords.length >= 1 && (() => {
                 const nextTiles = previewNextSpecialTiles(
                   usedWords.length,
-                  getDailySeed(),
+                  settings.mode === "daily_5x5" ? getDailySeed() + "-5x5" : getDailySeed(),
                   size,
                   specialTiles
                 );
@@ -5999,7 +6155,7 @@ function WordPathGame({
               <div className="text-xs text-muted-foreground text-right">
                 {usedWords.length >= 1 ? "Special tiles active!" : ""}
                 {gameOver && finalGrade !== "None" && <div className="mt-1 font-medium">Final: {finalGrade}</div>}
-                {settings.mode === "daily" && (
+                {(settings.mode === "daily" || settings.mode === "daily_5x5") && (
                   <>
                     <div className="mt-1 text-xs text-muted-foreground">
                       {settings.dailyMovesLimit - movesUsed} moves remaining
@@ -6007,7 +6163,7 @@ function WordPathGame({
                     {!gameOver && usedWords.length >= 1 && (() => {
                       const nextTiles = previewNextSpecialTiles(
                         usedWords.length,
-                        getDailySeed(),
+                        settings.mode === "daily_5x5" ? getDailySeed() + "-5x5" : getDailySeed(),
                         size,
                         specialTiles
                       );
@@ -6118,7 +6274,7 @@ function WordPathGame({
                   </div>
                  )}
                  */}
-                {settings.mode === "daily" && gameOver && <Button variant="outline" size="sm" onClick={shareScoreInline} className="mt-2 h-6 px-2 text-xs bg-background text-[hsl(var(--brand-500))] border-[hsl(var(--brand-500))] hover:bg-[hsl(var(--brand-50))] hover:text-[hsl(var(--brand-600))] dark:hover:bg-[hsl(var(--brand-950))]">
+                {(settings.mode === "daily" || settings.mode === "daily_5x5") && gameOver && <Button variant="outline" size="sm" onClick={shareScoreInline} className="mt-2 h-6 px-2 text-xs bg-background text-[hsl(var(--brand-500))] border-[hsl(var(--brand-500))] hover:bg-[hsl(var(--brand-50))] hover:text-[hsl(var(--brand-600))] dark:hover:bg-[hsl(var(--brand-950))]">
                     Share
                   </Button>}
                 {puzzleMode && gameOver && currentPuzzleId && (

--- a/src/components/game/WordPathGame.tsx
+++ b/src/components/game/WordPathGame.tsx
@@ -3584,7 +3584,7 @@ function WordPathGame({
     const consumable = CONSUMABLES[consumableId];
 
     // Check if consumable can be used in current mode
-    if (consumable.dailyModeOnly && settings.mode !== "daily") {
+    if (consumable.dailyModeOnly && settings.mode !== "daily" && settings.mode !== "daily_5x5") {
       toast.error("This consumable can only be used in Daily Challenge mode");
       return;
     }
@@ -3842,7 +3842,7 @@ function WordPathGame({
     return count;
   };
   const handleExtraMoves = () => {
-    if (settings.mode !== "daily") {
+    if (settings.mode !== "daily" && settings.mode !== "daily_5x5") {
       toast.error("Extra moves can only be used in Daily Challenge mode");
       return;
     }

--- a/src/components/game/WordPathGame.tsx
+++ b/src/components/game/WordPathGame.tsx
@@ -1741,8 +1741,6 @@ function WordPathGame({
     return false;
   };
 
-  const loadDailyState = () => loadDailyStateForMode("daily");
-
   // Strategic save function that prevents saves during initialization
   const saveGameState = useCallback(() => {
     if (settings.mode === "daily" && !isInitializing && board && board.length > 0) {

--- a/src/components/game/WordPathGame.tsx
+++ b/src/components/game/WordPathGame.tsx
@@ -1616,7 +1616,8 @@ function WordPathGame({
         avg_word_length: detailedAnalysis.avgWordLength,
         connectivity_score: detailedAnalysis.connectivityScore,
         max_score_potential: detailedAnalysis.maxScorePotential,
-        letter_distribution: Object.fromEntries(detailedAnalysis.letterDistribution)
+        letter_distribution: Object.fromEntries(detailedAnalysis.letterDistribution),
+        p_game_mode: settings.mode
       });
     } catch (boardAnalysisError) {
       console.warn('Failed to save board analysis (non-critical):', boardAnalysisError);
@@ -1630,7 +1631,8 @@ function WordPathGame({
       enhancedData,
       (progress) => {
         setSaveProgress(progress);
-      }
+      },
+      settings.mode
     );
     
     if (!saveSuccess) {
@@ -3255,7 +3257,7 @@ function WordPathGame({
             } = await import('@/integrations/supabase/client');
             bms = await computeDynamicBenchmarks(`practice-${Date.now()}`,
             // Unique seed for practice
-            probe.words.size, config.minWords, probe.analysis, supabase);
+            probe.words.size, config.minWords, probe.analysis, supabase, 'practice');
           } else {
             bms = computeBenchmarksFromWordCount(probe.words.size, config.minWords);
           }
@@ -3345,7 +3347,7 @@ function WordPathGame({
         let bms: Benchmarks;
         try {
           if (probe.analysis && user) {
-            bms = await computeDynamicBenchmarks(dailySeed, probe.words.size, config.minWords, probe.analysis, supabase);
+            bms = await computeDynamicBenchmarks(dailySeed, probe.words.size, config.minWords, probe.analysis, supabase, mode);
           } else if (probe.analysis) {
             bms = computeBoardSpecificBenchmarks(probe.words.size, config.minWords, probe.analysis);
           } else {
@@ -3466,7 +3468,7 @@ function WordPathGame({
         let bms: Benchmarks;
         try {
           if (probe.analysis && user) {
-            bms = await computeDynamicBenchmarks(getDailySeed(), probe.words.size, config.minWords, probe.analysis, supabase);
+            bms = await computeDynamicBenchmarks(getDailySeed(), probe.words.size, config.minWords, probe.analysis, supabase, settings.mode);
           } else if (probe.analysis) {
             bms = computeBoardSpecificBenchmarks(probe.words.size, config.minWords, probe.analysis);
           } else {

--- a/src/components/game/WordPathGame.tsx
+++ b/src/components/game/WordPathGame.tsx
@@ -1663,27 +1663,36 @@ function WordPathGame({
   const saveDailyStateForMode = async (
     mode: "daily" | "daily_5x5",
     initialBoardToSave?: string[][],
-    immediate = false
+    immediate = false,
+    options?: {
+      skipModeCheck?: boolean;
+      benchmarksOverride?: Benchmarks | null;
+      discoverableCountOverride?: number;
+      /** When starting a fresh game, pass full initial state to avoid stale closure values */
+      initialState?: Record<string, unknown>;
+    }
   ) => {
-    if (settings.mode !== mode) return;
+    if (!options?.skipModeCheck && settings.mode !== mode) return;
     const stateHook = mode === "daily" ? dailyChallengeState : dailyChallengeState5x5;
     const seed = mode === "daily" ? getDailySeed() : getDailySeed() + "-5x5";
-    const gameState = {
-      board,
-      initialBoard: initialBoardToSave || board,
-      specialTiles,
-      usedWords,
-      score,
-      streak,
-      movesUsed,
-      unlocked: Array.from(unlocked),
-      gameOver,
-      finalGrade,
-      lastWordTiles: Array.from(lastWordTiles),
-      seed,
-      benchmarks,
-      discoverableCount
-    };
+    const gameState = options?.initialState
+      ? { ...options.initialState, seed }
+      : {
+          board: initialBoardToSave ?? board,
+          initialBoard: initialBoardToSave ?? board,
+          specialTiles,
+          usedWords,
+          score,
+          streak,
+          movesUsed,
+          unlocked: Array.from(unlocked),
+          gameOver,
+          finalGrade,
+          lastWordTiles: Array.from(lastWordTiles),
+          seed,
+          benchmarks: options?.benchmarksOverride !== undefined ? options.benchmarksOverride : benchmarks,
+          discoverableCount: options?.discoverableCountOverride !== undefined ? options.discoverableCountOverride : discoverableCount
+        };
     await stateHook.saveState(gameState, immediate);
   };
 
@@ -1691,9 +1700,12 @@ function WordPathGame({
     saveDailyStateForMode("daily", initialBoardToSave, immediate);
   const saveDaily5x5State = (initialBoardToSave?: string[][], immediate = false) =>
     saveDailyStateForMode("daily_5x5", initialBoardToSave, immediate);
-  const loadDailyState = async () => {
-    const gameState = await dailyChallengeState.loadState();
-    if (gameState) {
+
+  // Load daily challenge state (shared logic for both daily and daily_5x5 modes)
+  const loadDailyStateForMode = async (mode: "daily" | "daily_5x5") => {
+    const stateHook = mode === "daily" ? dailyChallengeState : dailyChallengeState5x5;
+    const gameState = await stateHook.loadState();
+    if (gameState && gameState.board && gameState.initialBoard) {
       setBoard(gameState.board);
       setSpecialTiles(gameState.specialTiles);
       setUsedWords(gameState.usedWords);
@@ -1703,16 +1715,13 @@ function WordPathGame({
       setUnlocked(new Set(gameState.unlocked));
       setGameOver(gameState.gameOver);
       setFinalGrade(gameState.finalGrade);
-      // Restore last word tiles to show shaded tiles from previous attempt
       setLastWordTiles(new Set(gameState.lastWordTiles || []));
 
-      // Restore benchmarks and discoverable count, with fallback for backward compatibility
       if (gameState.benchmarks && gameState.discoverableCount !== undefined) {
         console.log("📊 Benchmarks restored from saved state:", gameState.benchmarks);
         setBenchmarks(gameState.benchmarks);
         setDiscoverableCount(gameState.discoverableCount);
       } else if (dict && sorted && gameState.initialBoard) {
-        // Fallback: recalculate benchmarks for existing saves without them
         console.log("📊 Dictionary loaded, recalculating benchmarks from initialBoard...");
         const config = DIFFICULTY_CONFIG["medium"];
         const probe = probeGrid(gameState.initialBoard, dict, sorted, config.minWords, MAX_DFS_NODES, true);
@@ -1727,13 +1736,12 @@ function WordPathGame({
           hasInitialBoard: !!gameState.initialBoard
         });
       }
-      return {
-        gameState,
-        hasInitialBoard: !!gameState.initialBoard
-      };
+      return { gameState, hasInitialBoard: true };
     }
     return false;
   };
+
+  const loadDailyState = () => loadDailyStateForMode("daily");
 
   // Strategic save function that prevents saves during initialization
   const saveGameState = useCallback(() => {
@@ -3283,40 +3291,40 @@ function WordPathGame({
       setSpecialTiles(createEmptySpecialTilesGrid(newSize));
     }
   }
-  async function startDailyChallenge() {
-    const difficulty = "medium"; // Daily challenges use medium difficulty
+  async function startDailyChallengeForMode(mode: "daily" | "daily_5x5") {
+    const difficulty = "medium";
     const config = DIFFICULTY_CONFIG[difficulty];
-    const newSize = config.gridSize;
-    const dailySeed = getDailySeed();
+    const newSize = mode === "daily" ? config.gridSize : 5;
+    const dailySeed = mode === "daily" ? getDailySeed() : getDailySeed() + "-5x5";
+    const modeLabel = mode === "daily" ? "Daily Challenge" : "5x5 Daily Challenge";
 
-    // Try to load existing daily state first
-    const loadResult = await loadDailyState();
+    const loadResult = await loadDailyStateForMode(mode);
     if (loadResult && loadResult.gameState) {
       setSettings(prev => ({
         ...prev,
         difficulty,
         gridSize: newSize,
-        mode: "daily",
+        mode,
         dailyMovesLimit: getDailyMovesLimit()
       }));
       setSize(newSize);
-      toast.success("Daily Challenge resumed!");
+      toast.success(`${modeLabel} resumed!`);
       return;
     }
 
-    // If no saved state, start fresh daily challenge
     setSettings(prev => ({
       ...prev,
       difficulty,
       gridSize: newSize,
-      mode: "daily",
+      mode,
       dailyMovesLimit: getDailyMovesLimit()
     }));
     setSize(newSize);
     const newBoard = makeBoard(newSize, dailySeed);
-    console.log(`Daily Challenge board generated with seed ${dailySeed}:`, newBoard[0].join(''), newBoard[1].join(''), newBoard[2].join(''), newBoard[3].join(''));
+    if (mode === "daily") {
+      console.log(`Daily Challenge board generated with seed ${dailySeed}:`, newBoard[0].join(''), newBoard[1].join(''), newBoard[2].join(''), newBoard[3].join(''));
+    }
 
-    // Reset all game state to initial values
     setPath([]);
     setDragging(false);
     setUsedWords([]);
@@ -3329,11 +3337,11 @@ function WordPathGame({
     setFinalGrade("None");
     setSpecialTiles(createEmptySpecialTilesGrid(newSize));
     setBoard(newBoard);
+
     if (dict && sorted) {
       setIsGenerating(true);
       try {
         const probe = probeGrid(newBoard, dict, sorted, config.minWords, MAX_DFS_NODES, true);
-        // Try to compute dynamic benchmarks first, fallback to static if needed
         let bms: Benchmarks;
         try {
           if (probe.analysis && user) {
@@ -3344,148 +3352,58 @@ function WordPathGame({
             bms = computeBenchmarksFromWordCount(probe.words.size, config.minWords);
           }
         } catch (error) {
-          console.error('Error computing benchmarks, falling back to static:', error);
+          console.error(`Error computing ${mode} benchmarks, falling back to static:`, error);
           bms = probe.analysis ? computeBoardSpecificBenchmarks(probe.words.size, config.minWords, probe.analysis) : computeBenchmarksFromWordCount(probe.words.size, config.minWords);
         }
         setBenchmarks(bms);
         setDiscoverableCount(probe.words.size);
-        toast.success(`Daily Challenge ${dailySeed} ready! ${settings.dailyMovesLimit} moves to make your best score.`);
+        toast.success(`${modeLabel} ready! ${getDailyMovesLimit()} moves to make your best score.`);
 
-        // Save the initial state with the initial board preserved (immediate save)
-        await saveDailyState(newBoard, true);
-      } finally {
-        setIsGenerating(false);
-      }
-    } else {
-      // Dictionary not loaded yet, set basic state and save board
-      setBenchmarks(null);
-      setDiscoverableCount(0);
-
-      // Save the initial board immediately, even without dictionary
-      await saveDailyState(newBoard, true);
-    }
-  }
-
-  async function startDaily5x5Challenge() {
-    const size5x5 = 5;
-    const dailySeed5x5 = getDailySeed() + "-5x5";
-    const config = DIFFICULTY_CONFIG["medium"];
-
-    // Try to load existing 5x5 daily state first
-    const savedState5x5 = await dailyChallengeState5x5.loadState();
-    if (savedState5x5 && savedState5x5.board && savedState5x5.initialBoard) {
-      setBoard(savedState5x5.board);
-      setSpecialTiles(savedState5x5.specialTiles);
-      setUsedWords(savedState5x5.usedWords);
-      setScore(savedState5x5.score);
-      setStreak(savedState5x5.streak);
-      setMovesUsed(savedState5x5.movesUsed);
-      setUnlocked(new Set(savedState5x5.unlocked));
-      setGameOver(savedState5x5.gameOver);
-      setFinalGrade(savedState5x5.finalGrade);
-      setLastWordTiles(new Set(savedState5x5.lastWordTiles || []));
-      if (savedState5x5.benchmarks && savedState5x5.discoverableCount !== undefined) {
-        setBenchmarks(savedState5x5.benchmarks);
-        setDiscoverableCount(savedState5x5.discoverableCount);
-      }
-      setSettings(prev => ({
-        ...prev,
-        difficulty: "medium",
-        gridSize: size5x5,
-        mode: "daily_5x5",
-        dailyMovesLimit: getDailyMovesLimit()
-      }));
-      setSize(size5x5);
-      toast.success("5x5 Daily Challenge resumed!");
-      return;
-    }
-
-    // Start fresh 5x5 daily challenge
-    setSettings(prev => ({
-      ...prev,
-      difficulty: "medium",
-      gridSize: size5x5,
-      mode: "daily_5x5",
-      dailyMovesLimit: getDailyMovesLimit()
-    }));
-    setSize(size5x5);
-    const newBoard5x5 = makeBoard(size5x5, dailySeed5x5);
-
-    // Reset all game state
-    setPath([]);
-    setDragging(false);
-    setUsedWords([]);
-    setLastWordTiles(new Set());
-    setScore(0);
-    setStreak(0);
-    setMovesUsed(0);
-    setUnlocked(new Set());
-    setGameOver(false);
-    setFinalGrade("None");
-    setSpecialTiles(createEmptySpecialTilesGrid(size5x5));
-    setBoard(newBoard5x5);
-
-    if (dict && sorted) {
-      setIsGenerating(true);
-      try {
-        const probe = probeGrid(newBoard5x5, dict, sorted, config.minWords, MAX_DFS_NODES, true);
-        let bms: Benchmarks;
-        try {
-          if (probe.analysis && user) {
-            bms = await computeDynamicBenchmarks(dailySeed5x5, probe.words.size, config.minWords, probe.analysis, supabase);
-          } else if (probe.analysis) {
-            bms = computeBoardSpecificBenchmarks(probe.words.size, config.minWords, probe.analysis);
-          } else {
-            bms = computeBenchmarksFromWordCount(probe.words.size, config.minWords);
-          }
-        } catch (error) {
-          console.error('Error computing 5x5 benchmarks, falling back to static:', error);
-          bms = probe.analysis ? computeBoardSpecificBenchmarks(probe.words.size, config.minWords, probe.analysis) : computeBenchmarksFromWordCount(probe.words.size, config.minWords);
-        }
-        setBenchmarks(bms);
-        setDiscoverableCount(probe.words.size);
-        toast.success(`5x5 Daily Challenge ready! ${getDailyMovesLimit()} moves to make your best score.`);
-
-        // Save initial state
-        const initialGameState = {
-          board: newBoard5x5,
-          initialBoard: newBoard5x5,
-          specialTiles: createEmptySpecialTilesGrid(size5x5),
-          usedWords: [],
+        const initialState = {
+          board: newBoard,
+          initialBoard: newBoard,
+          specialTiles: createEmptySpecialTilesGrid(newSize),
+          usedWords: [] as { word: string; score: number; breakdown?: ScoreBreakdown }[],
           score: 0,
           streak: 0,
           movesUsed: 0,
-          unlocked: [],
+          unlocked: [] as AchievementId[],
           gameOver: false,
           finalGrade: "None" as const,
-          lastWordTiles: [],
-          seed: dailySeed5x5,
+          lastWordTiles: [] as string[],
           benchmarks: bms,
           discoverableCount: probe.words.size
         };
-        await dailyChallengeState5x5.saveState(initialGameState, true);
+        await saveDailyStateForMode(mode, newBoard, true, { skipModeCheck: true, initialState });
       } finally {
         setIsGenerating(false);
       }
     } else {
       setBenchmarks(null);
       setDiscoverableCount(0);
-      const initialGameState = {
-        board: newBoard5x5,
-        initialBoard: newBoard5x5,
-        specialTiles: createEmptySpecialTilesGrid(size5x5),
-        usedWords: [],
+      const initialState = {
+        board: newBoard,
+        initialBoard: newBoard,
+        specialTiles: createEmptySpecialTilesGrid(newSize),
+        usedWords: [] as { word: string; score: number; breakdown?: ScoreBreakdown }[],
         score: 0,
         streak: 0,
         movesUsed: 0,
-        unlocked: [],
+        unlocked: [] as AchievementId[],
         gameOver: false,
         finalGrade: "None" as const,
-        lastWordTiles: [],
-        seed: dailySeed5x5
+        lastWordTiles: [] as string[]
       };
-      await dailyChallengeState5x5.saveState(initialGameState, true);
+      await saveDailyStateForMode(mode, newBoard, true, { skipModeCheck: true, initialState });
     }
+  }
+
+  async function startDailyChallenge() {
+    return startDailyChallengeForMode("daily");
+  }
+
+  async function startDaily5x5Challenge() {
+    return startDailyChallengeForMode("daily_5x5");
   }
 
   async function resetDailyChallenge() {

--- a/src/components/game/WordPathGame.tsx
+++ b/src/components/game/WordPathGame.tsx
@@ -1661,52 +1661,38 @@ function WordPathGame({
     }
   }, [gameOver, user, settings.mode, saveGameResult]);
 
-  // Save and restore daily challenge state
-  const saveDailyState = async (initialBoardToSave?: string[][], immediate = false) => {
-    if (settings.mode === "daily") {
-      const gameState = {
-        board,
-        initialBoard: initialBoardToSave || board,
-        // Use provided initial board or current board
-        specialTiles,
-        usedWords,
-        score,
-        streak,
-        movesUsed,
-        unlocked: Array.from(unlocked),
-        gameOver,
-        finalGrade,
-        lastWordTiles: Array.from(lastWordTiles),
-        seed: getDailySeed(),
-        benchmarks,
-        discoverableCount
-      };
-      await dailyChallengeState.saveState(gameState, immediate);
-    }
+  // Save daily challenge state (shared logic for both daily and daily_5x5 modes)
+  const saveDailyStateForMode = async (
+    mode: "daily" | "daily_5x5",
+    initialBoardToSave?: string[][],
+    immediate = false
+  ) => {
+    if (settings.mode !== mode) return;
+    const stateHook = mode === "daily" ? dailyChallengeState : dailyChallengeState5x5;
+    const seed = mode === "daily" ? getDailySeed() : getDailySeed() + "-5x5";
+    const gameState = {
+      board,
+      initialBoard: initialBoardToSave || board,
+      specialTiles,
+      usedWords,
+      score,
+      streak,
+      movesUsed,
+      unlocked: Array.from(unlocked),
+      gameOver,
+      finalGrade,
+      lastWordTiles: Array.from(lastWordTiles),
+      seed,
+      benchmarks,
+      discoverableCount
+    };
+    await stateHook.saveState(gameState, immediate);
   };
 
-  // Save 5x5 daily challenge state
-  const saveDaily5x5State = async (initialBoardToSave?: string[][], immediate = false) => {
-    if (settings.mode === "daily_5x5") {
-      const gameState = {
-        board,
-        initialBoard: initialBoardToSave || board,
-        specialTiles,
-        usedWords,
-        score,
-        streak,
-        movesUsed,
-        unlocked: Array.from(unlocked),
-        gameOver,
-        finalGrade,
-        lastWordTiles: Array.from(lastWordTiles),
-        seed: getDailySeed() + "-5x5",
-        benchmarks,
-        discoverableCount
-      };
-      await dailyChallengeState5x5.saveState(gameState, immediate);
-    }
-  };
+  const saveDailyState = (initialBoardToSave?: string[][], immediate = false) =>
+    saveDailyStateForMode("daily", initialBoardToSave, immediate);
+  const saveDaily5x5State = (initialBoardToSave?: string[][], immediate = false) =>
+    saveDailyStateForMode("daily_5x5", initialBoardToSave, immediate);
   const loadDailyState = async () => {
     const gameState = await dailyChallengeState.loadState();
     if (gameState) {

--- a/src/components/game/WordPathGame.tsx
+++ b/src/components/game/WordPathGame.tsx
@@ -1906,8 +1906,7 @@ function WordPathGame({
       console.log("📊 Dictionary loaded, recalculating benchmarks for resumed daily challenge...");
       setIsGenerating(true);
       try {
-        const difficulty = settings.difficulty || "medium";
-        const config = DIFFICULTY_CONFIG[difficulty];
+        const config = settings.mode === "daily_5x5" ? DAILY_5X5_CONFIG : DIFFICULTY_CONFIG[settings.difficulty || "medium"];
         const probe = probeGrid(board, dict, sorted, config.minWords, MAX_DFS_NODES, true);
         const bms = probe.analysis ? computeBoardSpecificBenchmarks(probe.words.size, config.minWords, probe.analysis) : computeBenchmarksFromWordCount(probe.words.size, config.minWords);
         console.log("📊 Benchmarks recalculated:", bms);
@@ -3120,6 +3119,9 @@ function WordPathGame({
       scoreMultiplier: 1.6
     }
   };
+  // 5x5 daily challenge uses minWords calibrated for 5x5 grids (hard config).
+  // Using medium's minWords (12) would miscalibrate benchmarks since 5x5 has far more valid words.
+  const DAILY_5X5_CONFIG = { minWords: DIFFICULTY_CONFIG.hard.minWords };
   function onNewGame() {
     setShowDifficultyDialog(true);
   }
@@ -3293,7 +3295,7 @@ function WordPathGame({
   }
   async function startDailyChallengeForMode(mode: "daily" | "daily_5x5") {
     const difficulty = "medium";
-    const config = DIFFICULTY_CONFIG[difficulty];
+    const config = mode === "daily_5x5" ? DAILY_5X5_CONFIG : DIFFICULTY_CONFIG[difficulty];
     const newSize = mode === "daily" ? config.gridSize : 5;
     const dailySeed = mode === "daily" ? getDailySeed() : getDailySeed() + "-5x5";
     const modeLabel = mode === "daily" ? "Daily Challenge" : "5x5 Daily Challenge";

--- a/src/components/game/WordPathGame.tsx
+++ b/src/components/game/WordPathGame.tsx
@@ -1723,7 +1723,7 @@ function WordPathGame({
         setDiscoverableCount(gameState.discoverableCount);
       } else if (dict && sorted && gameState.initialBoard) {
         console.log("📊 Dictionary loaded, recalculating benchmarks from initialBoard...");
-        const config = DIFFICULTY_CONFIG["medium"];
+        const config = mode === "daily_5x5" ? DAILY_5X5_CONFIG : DIFFICULTY_CONFIG["medium"];
         const probe = probeGrid(gameState.initialBoard, dict, sorted, config.minWords, MAX_DFS_NODES, true);
         const bms = probe.analysis ? computeBoardSpecificBenchmarks(probe.words.size, config.minWords, probe.analysis) : computeBenchmarksFromWordCount(probe.words.size, config.minWords);
         console.log("📊 Benchmarks recalculated from initialBoard:", bms);

--- a/src/components/game/WordPathGame.tsx
+++ b/src/components/game/WordPathGame.tsx
@@ -1585,9 +1585,9 @@ function WordPathGame({
     }
   }, [settings.mode, settings.difficulty, gameOver, user, usedWords, score, finalGrade, movesUsed, gameStartTime, size, unlocked]);
 
-  // Bulletproof daily challenge result saving
+  // Bulletproof daily challenge result saving (handles both daily and daily_5x5)
   const saveDailyChallengeResult = async () => {
-    if (!user || settings.mode !== "daily" || !gameOver) return;
+    if (!user || (settings.mode !== "daily" && settings.mode !== "daily_5x5") || !gameOver) return;
     
     // Prepare enhanced data for the progressive save strategy
     const detailedAnalysis = analyzeBoardComposition(board);
@@ -1644,10 +1644,8 @@ function WordPathGame({
   // Save game result when game ends
   useEffect(() => {
     if (gameOver) {
-      if (settings.mode === "daily") {
+      if (settings.mode === "daily" || settings.mode === "daily_5x5") {
         saveDailyChallengeResult();
-      } else if (settings.mode === "daily_5x5") {
-        // 5x5 daily state is auto-saved via the periodic save mechanism
       } else {
         saveGameResult();
       }

--- a/src/components/game/WordPathGame.tsx
+++ b/src/components/game/WordPathGame.tsx
@@ -4868,12 +4868,16 @@ function WordPathGame({
     // Get emoji based on grade
     const gradeEmoji = grade === "Platinum" ? "💎" : grade === "Gold" ? "🥇" : grade === "Silver" ? "🥈" : grade === "Bronze" ? "🥉" : "📊";
 
+    const is5x5 = settings.mode === "daily_5x5";
+    const modeLabel = is5x5 ? "Lexichain Daily 5×5" : "Lexichain Daily";
+    const shareTitle = is5x5 ? "Lexichain Daily 5×5 Challenge" : "Lexichain Daily Challenge";
+
     // Get highest single word score
     const topWordScore = usedWords.length > 0 ? Math.max(...usedWords.map(w => w.score)) : 0;
-    const shareText = `🔤 Lexichain Daily ${date}\n${gradeEmoji} ${score} points (${grade})\n📝 Top word: ${topWordScore}\n\nlexichain.lovable.app`;
+    const shareText = `🔤 ${modeLabel} ${date}\n${gradeEmoji} ${score} points (${grade})\n📝 Top word: ${topWordScore}\n\nlexichain.lovable.app`;
     if (navigator.share) {
       navigator.share({
-        title: 'Lexichain Daily Challenge',
+        title: shareTitle,
         text: shareText
       });
     } else {

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -61,6 +61,7 @@ export type Database = {
           challenge_date: string
           connectivity_score: number
           created_at: string | null
+          game_mode: string
           grid_size: number
           letter_distribution: Json
           max_score_potential: number
@@ -72,6 +73,7 @@ export type Database = {
           challenge_date: string
           connectivity_score?: number
           created_at?: string | null
+          game_mode?: string
           grid_size?: number
           letter_distribution?: Json
           max_score_potential?: number
@@ -83,6 +85,7 @@ export type Database = {
           challenge_date?: string
           connectivity_score?: number
           created_at?: string | null
+          game_mode?: string
           grid_size?: number
           letter_distribution?: Json
           max_score_potential?: number
@@ -97,6 +100,7 @@ export type Database = {
           board_analysis: Json | null
           challenge_date: string
           created_at: string
+          game_mode: string
           grid_size: number | null
           id: string
           score: number
@@ -109,6 +113,7 @@ export type Database = {
           board_analysis?: Json | null
           challenge_date: string
           created_at?: string
+          game_mode?: string
           grid_size?: number | null
           id?: string
           score: number
@@ -121,6 +126,7 @@ export type Database = {
           board_analysis?: Json | null
           challenge_date?: string
           created_at?: string
+          game_mode?: string
           grid_size?: number | null
           id?: string
           score?: number
@@ -560,7 +566,7 @@ export type Database = {
       }
       get_benchmark_data: { Args: { challenge_date: string }; Returns: Json }
       get_daily_leaderboard: {
-        Args: { challenge_date: string }
+        Args: { challenge_date: string; p_game_mode?: string }
         Returns: {
           display_name: string
           rank: number
@@ -569,11 +575,11 @@ export type Database = {
         }[]
       }
       get_enhanced_benchmark_data: {
-        Args: { challenge_date: string }
+        Args: { challenge_date: string; p_game_mode?: string }
         Returns: Json
       }
       get_monthly_leaderboard: {
-        Args: { month: number; year: number }
+        Args: { month: number; year: number; p_game_mode?: string }
         Returns: {
           best_score: number
           display_name: string
@@ -583,7 +589,7 @@ export type Database = {
       }
       get_week_start: { Args: { input_date?: string }; Returns: string }
       get_weekly_leaderboard: {
-        Args: { week_start: string }
+        Args: { week_start: string; p_game_mode?: string }
         Returns: {
           best_score: number
           display_name: string
@@ -615,6 +621,7 @@ export type Database = {
           grid_size: number
           letter_distribution: Json
           max_score_potential: number
+          p_game_mode?: string
           rarity_score_potential: number
           word_count: number
         }

--- a/src/lib/benchmarks.ts
+++ b/src/lib/benchmarks.ts
@@ -62,23 +62,25 @@ export async function computeDynamicBenchmarks(
   wordCount: number,
   kMin: number,
   analysis: BoardAnalysis,
-  supabaseClient: any
+  supabaseClient: any,
+  gameMode: string = 'daily'
 ): Promise<Benchmarks> {
-  const cacheKey = `${challengeDate}-${wordCount}-${kMin}-${analysis.maxScorePotential}`;
+  const cacheKey = `${challengeDate}-${wordCount}-${kMin}-${analysis.maxScorePotential}-${gameMode}`;
   
   // Clear cache to ensure fresh calculations after the data access fix
   const cached = benchmarkCache.get(cacheKey);
   if (cached && Date.now() - cached.timestamp < CACHE_DURATION) {
-    console.log(`Using cached benchmarks for ${challengeDate}:`, cached.benchmarks);
+    console.log(`Using cached benchmarks for ${challengeDate} (${gameMode}):`, cached.benchmarks);
     return cached.benchmarks;
   }
 
   try {
-    console.log(`Calculating dynamic benchmarks for ${challengeDate} using service function...`);
+    console.log(`Calculating dynamic benchmarks for ${challengeDate} (${gameMode}) using service function...`);
     
     // Use the enhanced benchmark function that includes board analysis
     const { data: benchmarkData, error } = await supabaseClient.rpc('get_enhanced_benchmark_data', {
-      challenge_date: challengeDate
+      challenge_date: challengeDate,
+      p_game_mode: gameMode
     });
 
     if (error) {

--- a/src/lib/progression.ts
+++ b/src/lib/progression.ts
@@ -161,6 +161,7 @@ export function calculateXpGain(params: {
   const modeMultipliers: Record<string, number> = {
     'classic': 1.0,
     'daily': 1.2,
+    'daily_5x5': 1.2,
     'practice': 0.8,
     'blitz': 1.5,
     'time_attack': 1.3,

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -13,6 +13,7 @@ import PuzzleSelector from "@/components/game/PuzzleSelector";
 import MiniMarathon from "@/components/game/MiniMarathon";
 import WeeklyGauntlet from "@/components/game/WeeklyGauntlet";
 import PrestigeEndless from "@/components/game/PrestigeEndless";
+import { FloatingTiles } from "@/components/effects/FloatingTiles";
 
 // Lazy load game component
 const WordPathGame = lazy(() => import("@/components/game/WordPathGame"));
@@ -24,7 +25,7 @@ const Index = () => {
   const [showMiniMarathon, setShowMiniMarathon] = useState(false);
   const [showWeeklyGauntlet, setShowWeeklyGauntlet] = useState(false);
   const [showPrestigeEndless, setShowPrestigeEndless] = useState(false);
-  const [selectedMode, setSelectedMode] = useState<"classic" | "daily" | "practice" | "blitz" | "time_attack" | "endless" | "puzzle" | "survival" | "zen">("classic");
+  const [selectedMode, setSelectedMode] = useState<"classic" | "daily" | "daily_5x5" | "practice" | "blitz" | "time_attack" | "endless" | "puzzle" | "survival" | "zen">("classic");
   const [selectedAdvancedMode, setSelectedAdvancedMode] = useState<AdvancedGameMode | null>(null);
   const [selectedPuzzleId, setSelectedPuzzleId] = useState<string | null>(null);
   const [user, setUser] = useState<User | null>(null);
@@ -103,7 +104,7 @@ const Index = () => {
   const handlePlayClick = () => {
     setShowModeSelection(true);
   };
-  const handleModeSelect = (mode: "classic" | "daily" | "practice" | "blitz" | "time_attack" | "endless" | "puzzle" | "survival" | "zen") => {
+  const handleModeSelect = (mode: "classic" | "daily" | "daily_5x5" | "practice" | "blitz" | "time_attack" | "endless" | "puzzle" | "survival" | "zen") => {
     setSelectedMode(mode);
     setShowModeSelection(false);
     setShowGame(true);
@@ -240,8 +241,9 @@ const Index = () => {
       </main>;
   }
   if (showModeSelection) {
-    return <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-background to-muted relative">
-        <div className="text-center space-y-8">
+    return <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-background to-muted relative overflow-hidden">
+        <FloatingTiles />
+        <div className="text-center space-y-8 relative z-10">
           <h1 className="text-6xl md:text-8xl font-extrabold tracking-tight bg-clip-text text-transparent bg-gradient-to-r from-[hsl(var(--brand-400))] to-[hsl(var(--brand-600))]">
             Lexichain
           </h1>
@@ -253,7 +255,15 @@ const Index = () => {
               <Button variant="hero" size="lg" onClick={() => handleModeSelect("daily")} className="px-12 py-4 text-lg">
                 Daily Challenge
               </Button>
-              
+
+              <Button
+                size="lg"
+                onClick={() => handleModeSelect("daily_5x5")}
+                className="px-12 py-4 text-lg bg-gradient-to-r from-teal-500 to-cyan-600 text-white shadow hover:brightness-110 hover:scale-[1.02] transition-all duration-200"
+              >
+                Daily Challenge 5x5
+              </Button>
+
               <Button variant="outline" size="lg" onClick={handleShowAdvancedModes} className="px-12 py-4 text-lg">
                 More Game Modes
               </Button>

--- a/src/pages/LeaderboardPage.tsx
+++ b/src/pages/LeaderboardPage.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router-dom";
 import { supabase } from "@/integrations/supabase/client";
 import { Button } from "@/components/ui/button";
 import type { User } from "@supabase/supabase-js";
+import { FloatingTiles } from "@/components/effects/FloatingTiles";
 
 export default function LeaderboardPage() {
   const [user, setUser] = useState<User | null>(null);
@@ -26,8 +27,9 @@ export default function LeaderboardPage() {
   }, []);
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-background to-muted/20 p-4">
-      <div className="container mx-auto py-8">
+    <div className="relative overflow-hidden min-h-screen bg-gradient-to-br from-background to-muted/20 p-4">
+      <FloatingTiles />
+      <div className="relative z-10 container mx-auto py-8">
         <div className="text-center mb-8">
           <h1 className="text-4xl font-bold mb-2">Leaderboards</h1>
           <p className="text-muted-foreground">

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -2,13 +2,15 @@ import { GameSettings } from '@/components/settings/GameSettings';
 import { Button } from '@/components/ui/button';
 import { ArrowLeft } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
+import { FloatingTiles } from '@/components/effects/FloatingTiles';
 
 export default function SettingsPage() {
   const navigate = useNavigate();
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-background to-muted py-8 px-4">
-      <div className="container mx-auto max-w-4xl">
+    <div className="relative overflow-hidden min-h-screen bg-gradient-to-br from-background to-muted py-8 px-4">
+      <FloatingTiles />
+      <div className="relative z-10 container mx-auto max-w-4xl">
         <div className="mb-6">
           <Button
             variant="ghost"

--- a/src/pages/StatsPage.tsx
+++ b/src/pages/StatsPage.tsx
@@ -12,6 +12,7 @@ import { GoalSelector } from "@/components/goals/GoalSelector";
 import { useGoals } from "@/hooks/useGoals";
 import { useToast } from "@/hooks/use-toast";
 import { parseISO, format } from "date-fns";
+import { FloatingTiles } from "@/components/effects/FloatingTiles";
 
 const StatsPage = () => {
   const navigate = useNavigate();
@@ -317,8 +318,9 @@ const StatsPage = () => {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-background to-muted">
-      <div className="container mx-auto px-4 py-8">
+    <div className="relative overflow-hidden min-h-screen bg-gradient-to-br from-background to-muted">
+      <FloatingTiles />
+      <div className="relative z-10 container mx-auto px-4 py-8">
         <div className="flex items-center gap-4 mb-8">
           <Button
             variant="outline"

--- a/src/pages/StorePage.tsx
+++ b/src/pages/StorePage.tsx
@@ -5,6 +5,7 @@ import { Link } from "react-router-dom";
 import { ConsumableStore } from "@/components/store/ConsumableStore";
 import { supabase } from "@/integrations/supabase/client";
 import type { User } from "@supabase/supabase-js";
+import { FloatingTiles } from "@/components/effects/FloatingTiles";
 
 export default function StorePage() {
   const [user, setUser] = useState<User | null>(null);
@@ -41,8 +42,9 @@ export default function StorePage() {
   }
 
   return (
-    <div className="min-h-screen bg-background">
-      <div className="container mx-auto px-4 py-6">
+    <div className="relative overflow-hidden min-h-screen bg-background">
+      <FloatingTiles />
+      <div className="relative z-10 container mx-auto px-4 py-6">
         {/* Header */}
         <div className="flex items-center gap-4 mb-6">
           <Button variant="outline" size="sm" asChild>

--- a/src/utils/dailyChallengeResultSaver.ts
+++ b/src/utils/dailyChallengeResultSaver.ts
@@ -8,6 +8,7 @@ export interface BasicDailyChallengeResult {
   challenge_date: string;
   score: number;
   achievement_level: string;
+  game_mode: string;
 }
 
 export interface EnhancedDailyChallengeResult extends BasicDailyChallengeResult {
@@ -122,12 +123,12 @@ async function progressiveSave(
       const { error } = await supabase
         .from("daily_challenge_results")
         .upsert(enhancedResult, {
-          onConflict: 'user_id,challenge_date',
+          onConflict: 'user_id,challenge_date,game_mode',
           ignoreDuplicates: false
         });
       
       if (!error) {
-        console.log('[Daily Challenge] Enhanced save successful');
+        console.log(`[Daily Challenge] Enhanced save successful for mode: ${basicResult.game_mode}`);
         return true;
       }
       
@@ -144,12 +145,12 @@ async function progressiveSave(
     const { error } = await supabase
       .from("daily_challenge_results")
       .upsert(basicResult, {
-        onConflict: 'user_id,challenge_date',
+        onConflict: 'user_id,challenge_date,game_mode',
         ignoreDuplicates: false
       });
     
     if (!error) {
-      console.log('[Daily Challenge] Basic save successful');
+      console.log(`[Daily Challenge] Basic save successful for mode: ${basicResult.game_mode}`);
       return true;
     }
     
@@ -169,7 +170,8 @@ export async function saveDailyChallengeResultBulletproof(
   score: number,
   achievementLevel: string,
   enhancedData?: Partial<EnhancedDailyChallengeResult>,
-  onProgress?: (progress: SaveProgress) => void
+  onProgress?: (progress: SaveProgress) => void,
+  gameMode: string = 'daily'
 ): Promise<boolean> {
   
   onProgress?.({ stage: 'validation' });
@@ -200,7 +202,8 @@ export async function saveDailyChallengeResultBulletproof(
     user_id: user.id,
     challenge_date: challengeDate,
     score,
-    achievement_level: achievementLevel
+    achievement_level: achievementLevel,
+    game_mode: gameMode
   };
   
   // Create immediate backup on mobile devices
@@ -288,9 +291,10 @@ export async function syncOfflineDailyChallengeResults(): Promise<number> {
           user_id: backupData.user_id,
           challenge_date: backupData.challenge_date,
           score: backupData.score,
-          achievement_level: backupData.achievement_level
+          achievement_level: backupData.achievement_level,
+          game_mode: backupData.game_mode || 'daily'
         }, {
-          onConflict: 'user_id,challenge_date',
+          onConflict: 'user_id,challenge_date,game_mode',
           ignoreDuplicates: false
         });
       

--- a/supabase/migrations/20260217120000_add_game_mode_to_daily_challenges.sql
+++ b/supabase/migrations/20260217120000_add_game_mode_to_daily_challenges.sql
@@ -1,0 +1,278 @@
+-- Add game_mode column to daily_challenge_results to differentiate between daily (4x4) and daily_5x5 modes
+-- Previously, both modes shared the same (user_id, challenge_date) unique key, causing the second result to overwrite the first
+
+-- Step 1: Add game_mode column to daily_challenge_results
+ALTER TABLE public.daily_challenge_results 
+  ADD COLUMN IF NOT EXISTS game_mode TEXT NOT NULL DEFAULT 'daily';
+
+-- Step 2: Drop the old unique constraint and create a new one including game_mode
+ALTER TABLE public.daily_challenge_results 
+  DROP CONSTRAINT IF EXISTS daily_challenge_results_user_id_challenge_date_key;
+
+ALTER TABLE public.daily_challenge_results 
+  ADD CONSTRAINT daily_challenge_results_user_id_challenge_date_game_mode_key 
+  UNIQUE (user_id, challenge_date, game_mode);
+
+-- Step 3: Add game_mode column to daily_challenge_board_analysis
+ALTER TABLE public.daily_challenge_board_analysis 
+  ADD COLUMN IF NOT EXISTS game_mode TEXT NOT NULL DEFAULT 'daily';
+
+-- Step 4: Drop the old primary key and create a new composite primary key
+ALTER TABLE public.daily_challenge_board_analysis 
+  DROP CONSTRAINT IF EXISTS daily_challenge_board_analysis_pkey;
+
+ALTER TABLE public.daily_challenge_board_analysis 
+  ADD CONSTRAINT daily_challenge_board_analysis_pkey 
+  PRIMARY KEY (challenge_date, game_mode);
+
+-- Step 5: Update save_daily_challenge_board_analysis function to accept game_mode
+CREATE OR REPLACE FUNCTION public.save_daily_challenge_board_analysis(
+  challenge_date date,
+  word_count integer,
+  grid_size integer,
+  rarity_score_potential numeric,
+  avg_word_length numeric,
+  connectivity_score numeric,
+  max_score_potential integer,
+  letter_distribution jsonb,
+  p_game_mode text DEFAULT 'daily'
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $function$
+BEGIN
+  INSERT INTO public.daily_challenge_board_analysis (
+    challenge_date,
+    word_count,
+    grid_size,
+    rarity_score_potential,
+    avg_word_length,
+    connectivity_score,
+    max_score_potential,
+    letter_distribution,
+    game_mode
+  )
+  VALUES (
+    challenge_date,
+    word_count,
+    grid_size,
+    rarity_score_potential,
+    avg_word_length,
+    connectivity_score,
+    max_score_potential,
+    letter_distribution,
+    p_game_mode
+  )
+  ON CONFLICT (challenge_date, game_mode) 
+  DO UPDATE SET
+    word_count = EXCLUDED.word_count,
+    grid_size = EXCLUDED.grid_size,
+    rarity_score_potential = EXCLUDED.rarity_score_potential,
+    avg_word_length = EXCLUDED.avg_word_length,
+    connectivity_score = EXCLUDED.connectivity_score,
+    max_score_potential = EXCLUDED.max_score_potential,
+    letter_distribution = EXCLUDED.letter_distribution;
+END;
+$function$;
+
+-- Step 6: Update get_enhanced_benchmark_data to filter by game_mode
+CREATE OR REPLACE FUNCTION public.get_enhanced_benchmark_data(challenge_date text, p_game_mode text DEFAULT 'daily')
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $function$
+DECLARE
+  benchmark_data record;
+  board_analysis record;
+  result jsonb;
+  board_difficulty_modifier numeric := 1.0;
+BEGIN
+  SELECT * INTO benchmark_data 
+  FROM public.calculate_daily_challenge_benchmarks(challenge_date::date, 30, p_game_mode);
+  
+  SELECT * INTO board_analysis
+  FROM public.daily_challenge_board_analysis ba
+  WHERE ba.challenge_date = get_enhanced_benchmark_data.challenge_date::date
+    AND ba.game_mode = p_game_mode;
+  
+  IF board_analysis IS NOT NULL THEN
+    board_difficulty_modifier := GREATEST(0.5, LEAST(2.0, 
+      (board_analysis.rarity_score_potential / 100.0) * 
+      (1.0 / GREATEST(0.1, board_analysis.connectivity_score / 100.0))
+    ));
+  END IF;
+  
+  result := jsonb_build_object(
+    'bronzePercentile', (benchmark_data.bronze_percentile * board_difficulty_modifier)::integer,
+    'silverPercentile', (benchmark_data.silver_percentile * board_difficulty_modifier)::integer,
+    'goldPercentile', (benchmark_data.gold_percentile * board_difficulty_modifier)::integer,
+    'platinumPercentile', (benchmark_data.platinum_percentile * board_difficulty_modifier)::integer,
+    'totalScores', benchmark_data.total_scores,
+    'minScore', benchmark_data.min_score,
+    'maxScore', benchmark_data.max_score,
+    'avgScore', benchmark_data.avg_score,
+    'boardDifficultyModifier', board_difficulty_modifier,
+    'boardAnalysis', COALESCE(to_jsonb(board_analysis), '{}'::jsonb)
+  );
+  
+  INSERT INTO public.security_audit_log (event_type, event_level, event_details, user_id, created_at)
+  VALUES (
+    'ENHANCED_BENCHMARK_CALCULATION',
+    'INFO',
+    jsonb_build_object(
+      'challenge_date', challenge_date,
+      'game_mode', p_game_mode,
+      'difficulty_modifier', board_difficulty_modifier,
+      'has_board_analysis', board_analysis IS NOT NULL
+    ),
+    auth.uid(),
+    now()
+  );
+  
+  RETURN result;
+END;
+$function$;
+
+-- Step 7: Update calculate_daily_challenge_benchmarks to filter by game_mode
+CREATE OR REPLACE FUNCTION public.calculate_daily_challenge_benchmarks(
+  target_challenge_date date,
+  days_back integer DEFAULT 30,
+  p_game_mode text DEFAULT 'daily'
+)
+RETURNS TABLE (
+  bronze_percentile integer,
+  silver_percentile integer, 
+  gold_percentile integer,
+  platinum_percentile integer,
+  total_scores integer,
+  min_score integer,
+  max_score integer,
+  avg_score numeric
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $function$
+DECLARE
+  start_date date;
+  scores_array integer[];
+  sorted_scores integer[];
+  total_count integer;
+BEGIN
+  start_date := target_challenge_date - days_back;
+  
+  SELECT array_agg(dcr.score ORDER BY dcr.score)
+  INTO scores_array
+  FROM public.daily_challenge_results dcr
+  WHERE dcr.challenge_date >= start_date
+    AND dcr.challenge_date < target_challenge_date
+    AND dcr.score > 0
+    AND dcr.game_mode = p_game_mode;
+  
+  IF scores_array IS NULL OR array_length(scores_array, 1) IS NULL THEN
+    RETURN QUERY SELECT 0, 0, 0, 0, 0, 0, 0, 0::numeric;
+    RETURN;
+  END IF;
+  
+  total_count := array_length(scores_array, 1);
+  
+  RETURN QUERY SELECT 
+    scores_array[GREATEST(1, LEAST(total_count, (total_count * 0.30)::integer))] as bronze_percentile,
+    scores_array[GREATEST(1, LEAST(total_count, (total_count * 0.50)::integer))] as silver_percentile,
+    scores_array[GREATEST(1, LEAST(total_count, (total_count * 0.85)::integer))] as gold_percentile,
+    scores_array[GREATEST(1, LEAST(total_count, (total_count * 0.98)::integer))] as platinum_percentile,
+    total_count,
+    scores_array[1] as min_score,
+    scores_array[total_count] as max_score,
+    (SELECT avg(score)::numeric FROM unnest(scores_array) as score) as avg_score;
+END;
+$function$;
+
+-- Step 8: Update leaderboard functions to accept game_mode parameter
+
+-- Daily leaderboard
+CREATE OR REPLACE FUNCTION get_daily_leaderboard(challenge_date DATE, p_game_mode TEXT DEFAULT 'daily')
+RETURNS TABLE(
+    user_id UUID,
+    display_name TEXT,
+    score INTEGER,
+    rank BIGINT
+) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT 
+        dcr.user_id,
+        COALESCE(p.display_name, 'Anonymous') as display_name,
+        dcr.score,
+        ROW_NUMBER() OVER (ORDER BY dcr.score DESC) as rank
+    FROM daily_challenge_results dcr
+    LEFT JOIN profiles p ON dcr.user_id = p.user_id
+    WHERE dcr.challenge_date = get_daily_leaderboard.challenge_date
+      AND dcr.game_mode = p_game_mode
+    ORDER BY dcr.score DESC
+    LIMIT 100;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Weekly leaderboard
+CREATE OR REPLACE FUNCTION get_weekly_leaderboard(week_start DATE, p_game_mode TEXT DEFAULT 'daily')
+RETURNS TABLE(
+    user_id UUID,
+    display_name TEXT,
+    best_score INTEGER,
+    rank BIGINT
+) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT 
+        dcr.user_id,
+        COALESCE(p.display_name, 'Anonymous') as display_name,
+        MAX(dcr.score) as best_score,
+        ROW_NUMBER() OVER (ORDER BY MAX(dcr.score) DESC) as rank
+    FROM daily_challenge_results dcr
+    LEFT JOIN profiles p ON dcr.user_id = p.user_id
+    WHERE dcr.challenge_date >= week_start 
+    AND dcr.challenge_date < week_start + INTERVAL '7 days'
+    AND dcr.game_mode = p_game_mode
+    GROUP BY dcr.user_id, p.display_name
+    ORDER BY MAX(dcr.score) DESC
+    LIMIT 100;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Monthly leaderboard
+CREATE OR REPLACE FUNCTION get_monthly_leaderboard(year INTEGER, month INTEGER, p_game_mode TEXT DEFAULT 'daily')
+RETURNS TABLE(
+    user_id UUID,
+    display_name TEXT,
+    best_score INTEGER,
+    rank BIGINT
+) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT 
+        dcr.user_id,
+        COALESCE(p.display_name, 'Anonymous') as display_name,
+        MAX(dcr.score) as best_score,
+        ROW_NUMBER() OVER (ORDER BY MAX(dcr.score) DESC) as rank
+    FROM daily_challenge_results dcr
+    LEFT JOIN profiles p ON dcr.user_id = p.user_id
+    WHERE EXTRACT(YEAR FROM dcr.challenge_date) = year
+    AND EXTRACT(MONTH FROM dcr.challenge_date) = month
+    AND dcr.game_mode = p_game_mode
+    GROUP BY dcr.user_id, p.display_name
+    ORDER BY MAX(dcr.score) DESC
+    LIMIT 100;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Step 9: Update indexes
+DROP INDEX IF EXISTS idx_daily_challenge_results_board_analysis;
+DROP INDEX IF EXISTS idx_daily_challenge_results_enhanced;
+CREATE INDEX IF NOT EXISTS idx_daily_challenge_results_mode ON daily_challenge_results(game_mode);
+CREATE INDEX IF NOT EXISTS idx_daily_challenge_results_date_mode ON daily_challenge_results(challenge_date, game_mode);
+CREATE INDEX IF NOT EXISTS idx_daily_challenge_results_enhanced ON daily_challenge_results(challenge_date, game_mode, word_count, grid_size);
+CREATE INDEX IF NOT EXISTS idx_daily_challenge_board_analysis_date_mode ON daily_challenge_board_analysis(challenge_date, game_mode);


### PR DESCRIPTION
## Summary
This PR introduces a new "Daily Challenge 5x5" game mode that provides a compact 5x5 grid variant of the daily challenge with its own independent state management and seeding system.

## Key Changes

- **New Game Mode**: Added `"daily_5x5"` to the `GameMode` type union, enabling it as a selectable game mode alongside the standard daily challenge
- **Dedicated State Management**: Implemented `dailyChallengeState5x5` using a separate seed (`getDailySeed() + "-5x5"`) to ensure 5x5 daily challenges are independent from standard daily challenges
- **Save/Load Functionality**: Created `saveDaily5x5State()` function to persist 5x5 game state with the same structure as standard daily challenges
- **Game Initialization**: Added `startDaily5x5Challenge()` function that:
  - Loads existing 5x5 daily state if available
  - Generates a fresh 5x5 board with medium difficulty if starting new
  - Calculates benchmarks and discoverable word counts
  - Applies the same move limit as standard daily challenges
- **UI Integration**: 
  - Added "Daily Challenge 5x5" button to mode selection screen with teal/cyan gradient styling
  - Updated all daily challenge UI elements (move counter, special tile preview, share button) to support both daily modes
- **Game Logic Updates**: Extended move limit checks, special tile seeding, and game-over conditions to handle both `"daily"` and `"daily_5x5"` modes consistently
- **Visual Enhancement**: Integrated `FloatingTiles` background component across multiple pages (Index, AdvancedGameModes, PuzzleSelector, AuthForm, MiniMarathon, PrestigeEndless, WeeklyGauntlet, LeaderboardPage, SettingsPage, StatsPage, StorePage) for consistent visual styling

## Implementation Details

- The 5x5 mode uses the same `getDailyMovesLimit()` as standard daily challenges
- Special tiles are seeded using the modified seed to ensure consistency across players
- The mode respects all daily challenge constraints (move limits, no enhanced powerups) while maintaining a smaller grid size
- State persistence uses the same `useDailyChallengeState` hook with a differentiated seed key

https://claude.ai/code/session_01FD7X8KCJYtBuL69nNQM2Ni

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Daily Challenge flow plus database constraints/RPC signatures; incorrect mode propagation or migration issues could cause lost/merged results or broken leaderboards/benchmarks.
> 
> **Overview**
> Introduces a new **`daily_5x5` Daily Challenge** that runs on a fixed 5×5 grid with its own seed, save/load state, move-limit handling, special-tile seeding, and share text; `WordPathGame` is refactored to generalize daily state persistence across both daily modes.
> 
> Updates **Supabase schema and RPCs** to support mode-scoped daily data: adds `game_mode` to `daily_challenge_results` and `daily_challenge_board_analysis`, changes conflict keys/primary keys accordingly, and extends leaderboard/benchmark functions to accept `p_game_mode`; client benchmark caching and daily-result saving now include `gameMode`.
> 
> Adds the `Daily Challenge 5x5` option to the mode selector and applies the `FloatingTiles` background effect across multiple pages/components for consistent visuals.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe6e6e0b49cea1940e4118f29742dc3bf3a98268. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->