### PR TITLE
Fix: fail loudly when service_role_key vault secret is missing

### DIFF
--- a/supabase/migrations/20250909025208_ba7f30d7-a9e7-4ba3-902f-c92d3987de9d.sql
+++ b/supabase/migrations/20250909025208_ba7f30d7-a9e7-4ba3-902f-c92d3987de9d.sql
@@ -15,11 +15,12 @@ SELECT cron.schedule(
     url:='https://bfmofulvsqojwuqyhfqq.supabase.co/functions/v1/distribute-daily-rewards',
     headers:=jsonb_build_object(
       'Content-Type', 'application/json',
-      'Authorization', 'Bearer ' || (
-        SELECT decrypted_secret
-        FROM vault.decrypted_secrets
-        WHERE name = 'service_role_key'
-        LIMIT 1
+      'Authorization', 'Bearer ' || COALESCE(
+        (SELECT decrypted_secret
+         FROM vault.decrypted_secrets
+         WHERE name = 'service_role_key'
+         LIMIT 1),
+        (SELECT 1/0)  -- Fail loudly if service_role_key secret is missing from vault
       )
     ),
     body:='{}'::jsonb
@@ -36,11 +37,12 @@ SELECT cron.schedule(
     url:='https://bfmofulvsqojwuqyhfqq.supabase.co/functions/v1/distribute-weekly-rewards',
     headers:=jsonb_build_object(
       'Content-Type', 'application/json',
-      'Authorization', 'Bearer ' || (
-        SELECT decrypted_secret
-        FROM vault.decrypted_secrets
-        WHERE name = 'service_role_key'
-        LIMIT 1
+      'Authorization', 'Bearer ' || COALESCE(
+        (SELECT decrypted_secret
+         FROM vault.decrypted_secrets
+         WHERE name = 'service_role_key'
+         LIMIT 1),
+        (SELECT 1/0)  -- Fail loudly if service_role_key secret is missing from vault
       )
     ),
     body:='{}'::jsonb
@@ -57,11 +59,12 @@ SELECT cron.schedule(
     url:='https://bfmofulvsqojwuqyhfqq.supabase.co/functions/v1/distribute-monthly-rewards',
     headers:=jsonb_build_object(
       'Content-Type', 'application/json',
-      'Authorization', 'Bearer ' || (
-        SELECT decrypted_secret
-        FROM vault.decrypted_secrets
-        WHERE name = 'service_role_key'
-        LIMIT 1
+      'Authorization', 'Bearer ' || COALESCE(
+        (SELECT decrypted_secret
+         FROM vault.decrypted_secrets
+         WHERE name = 'service_role_key'
+         LIMIT 1),
+        (SELECT 1/0)  -- Fail loudly if service_role_key secret is missing from vault
       )
     ),
     body:='{}'::jsonb


### PR DESCRIPTION
Add COALESCE guard so that when the service_role_key secret is missing (not yet created, deleted, or misspelled), the cron job raises an error instead of silently sending requests with Authorization: null. Without this, all three reward distributions would report success but the edge function would reject with 401.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk SQL-only change that affects scheduled reward distribution calls; main risk is cron jobs now hard-fail if the Vault secret is absent/misnamed, which could halt distributions until fixed.
> 
> **Overview**
> Adds a `COALESCE` guard to the daily/weekly/monthly leaderboard reward `cron.schedule` HTTP calls so the `Authorization` header **fails loudly** when `vault.decrypted_secrets.name = 'service_role_key'` is missing (via a forced SQL error), rather than silently issuing requests with an invalid token.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca88e1b67ac32a6186fa9d5e748d9d118d1d5c77. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->