### PR TITLE
Fix multi-wild special tile submission flow

### DIFF
--- a/src/components/game/WordPathGame.tsx
+++ b/src/components/game/WordPathGame.tsx
@@ -2214,7 +2214,7 @@ function WordPathGame({
     // Handle shuffle tiles (use updated board from X-factor)
     trackedBoard = handleShuffleTiles(
       wordPath, 
-      specialTiles, 
+      trackedSpecialTiles, 
       trackedBoard, 
       size, 
       setBoard, 
@@ -2222,7 +2222,7 @@ function WordPathGame({
     );
 
     // Handle Bomb tile blasts (after scoring, before clearing path tiles)
-    const bombTilesInPath = wordPath.filter(p => specialTiles[p.r][p.c].type === "bomb");
+    const bombTilesInPath = wordPath.filter(p => trackedSpecialTiles[p.r][p.c].type === "bomb");
     if (bombTilesInPath.length > 0) {
       for (const bombPos of bombTilesInPath) {
         const bombResult = handleBombBlast(bombPos, trackedBoard, trackedSpecialTiles, size, setBoard, setSpecialTiles, setAffectedTiles);
@@ -4247,7 +4247,7 @@ function WordPathGame({
     // Handle shuffle tiles (use updated board from X-factor)
     trackedBoard = handleShuffleTiles(
       path, 
-      specialTiles, 
+      trackedSpecialTiles, 
       trackedBoard, 
       size, 
       setBoard, 
@@ -4255,7 +4255,7 @@ function WordPathGame({
     );
 
     // Handle Bomb tile blasts (after scoring, before clearing path tiles)
-    const bombTilesInPath = path.filter(p => specialTiles[p.r][p.c].type === "bomb");
+    const bombTilesInPath = path.filter(p => trackedSpecialTiles[p.r][p.c].type === "bomb");
     if (bombTilesInPath.length > 0) {
       for (const bombPos of bombTilesInPath) {
         const bombResult = handleBombBlast(bombPos, trackedBoard, trackedSpecialTiles, size, setBoard, setSpecialTiles, setAffectedTiles);

--- a/src/components/game/WordPathGame.tsx
+++ b/src/components/game/WordPathGame.tsx
@@ -1944,19 +1944,27 @@ function WordPathGame({
   function handleWildSubmit() {
     if (!pendingWildPath || !wildTileInputs.size || !dict) return;
     const wildcardPositions = pendingWildPath.filter(p => specialTiles[p.r][p.c].type === "wild");
-    if (wildcardPositions.length !== 1) return;
-    const wildPos = wildcardPositions[0];
-    const wildIndex = pendingWildPath.findIndex(p => p.r === wildPos.r && p.c === wildPos.c);
+    if (wildcardPositions.length === 0) return;
+
+    const submittedWildLetters = wildcardPositions.map(pos => {
+      const wildKey = `${pos.r}-${pos.c}`;
+      return (wildTileInputs.get(wildKey) || '').toLowerCase();
+    });
+    if (submittedWildLetters.some(letter => !/^[a-z]$/.test(letter))) {
+      toast.error("Please enter a letter for every Wild tile.");
+      return;
+    }
 
     // Create the word with the user's chosen letter, respecting ghost/mirror behavior
     const letters: string[] = [];
+    let wildLetterIndex = 0;
     for (let i = 0; i < pendingWildPath.length; i++) {
       const p = pendingWildPath[i];
       const tile = specialTiles[p.r][p.c];
       
-      if (i === wildIndex) {
-        const wildKey = `${wildPos.r}-${wildPos.c}`;
-        letters.push((wildTileInputs.get(wildKey) || '').toLowerCase());
+      if (tile.type === "wild") {
+        letters.push(submittedWildLetters[wildLetterIndex] || "");
+        wildLetterIndex++;
       } else if (tile.type === "ghost") {
         continue; // Ghost contributes no letter
       } else if (tile.type === "mirror") {
@@ -1986,14 +1994,17 @@ function WordPathGame({
     setWildTileInputs(new Map());
 
     // Set the path back and continue submission with the chosen word
-    setPath(pendingWildPath);
+    const submittedPath = [...pendingWildPath];
+    setPath(submittedPath);
     setPendingWildPath(null);
 
     // Now continue with the normal submission process using the validated word
     setTimeout(() => {
-      const wildKey = `${wildPos.r}-${wildPos.c}`;
-      const wildLetter = wildTileInputs.get(wildKey) || '';
-      submitWordWithWildLetter(testWord, pendingWildPath, wildLetter.toLowerCase());
+      if (submittedWildLetters.length > 1) {
+        submitWordWithWildLetters(testWord, submittedPath, submittedWildLetters);
+      } else {
+        submitWordWithWildLetter(testWord, submittedPath, submittedWildLetters[0]);
+      }
     }, 0);
   }
   // Create a new function for multiple wild letters
@@ -5296,11 +5307,11 @@ function WordPathGame({
       <Dialog open={showWildDialog} onOpenChange={setShowWildDialog}>
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
-            <DialogTitle>Choose Wild Tile Letter</DialogTitle>
+            <DialogTitle>Choose Wild Tile Letter{pendingWildPath?.filter(p => specialTiles[p.r][p.c].type === "wild").length === 1 ? "" : "s"}</DialogTitle>
           </DialogHeader>
           <div className="space-y-4">
             <div className="text-sm text-muted-foreground">
-              Enter a letter for the Wild tile to complete your word:
+              Enter a letter for each Wild tile to complete your word:
             </div>
             <div className="text-center">
               <div className="text-lg font-mono bg-muted p-2 rounded">
@@ -5314,22 +5325,24 @@ function WordPathGame({
               })}
               </div>
             </div>
-            <div>
-              <Input type="text" value={(wildTileInputs.get(`${pendingWildPath?.find(p => specialTiles[p.r][p.c].type === "wild")?.r}-${pendingWildPath?.find(p => specialTiles[p.r][p.c].type === "wild")?.c}`) || '')} onChange={e => {
-                if (pendingWildPath) {
-                  const wildPos = pendingWildPath.find(p => specialTiles[p.r][p.c].type === "wild");
-                  if (wildPos) {
-                    const wildKey = `${wildPos.r}-${wildPos.c}`;
-                    const newInputs = new Map(wildTileInputs);
-                    newInputs.set(wildKey, e.target.value.slice(0, 1).toUpperCase());
-                    setWildTileInputs(newInputs);
-                  }
-                }
+            <div className="space-y-2">
+              {(pendingWildPath?.filter(p => specialTiles[p.r][p.c].type === "wild") || []).map((wildPos, idx) => {
+              const wildKey = `${wildPos.r}-${wildPos.c}`;
+              return <Input key={wildKey} type="text" value={wildTileInputs.get(wildKey) || ''} onChange={e => {
+                const newInputs = new Map(wildTileInputs);
+                newInputs.set(wildKey, e.target.value.slice(0, 1).toUpperCase());
+                setWildTileInputs(newInputs);
               }} onKeyDown={e => {
-              if (e.key === 'Enter' && wildTileInputs.size > 0) {
+              const wildCount = pendingWildPath?.filter(p => specialTiles[p.r][p.c].type === "wild").length || 0;
+              const allFilled = wildCount > 0 && (pendingWildPath?.filter(p => specialTiles[p.r][p.c].type === "wild") || []).every(pos => {
+                const key = `${pos.r}-${pos.c}`;
+                return /^[A-Z]$/.test(wildTileInputs.get(key) || '');
+              });
+              if (e.key === 'Enter' && allFilled) {
                 handleWildSubmit();
               }
-            }} placeholder="Enter letter (A-Z)" className="w-full text-center text-lg font-mono" maxLength={1} autoFocus />
+            }} placeholder={`Wild tile ${idx + 1} letter (A-Z)`} className="w-full text-center text-lg font-mono" maxLength={1} autoFocus={idx === 0} />;
+            })}
             </div>
             <div className="flex gap-2">
               <Button variant="outline" onClick={() => {
@@ -5339,7 +5352,14 @@ function WordPathGame({
             }} className="flex-1">
                 Cancel
               </Button>
-              <Button onClick={handleWildSubmit} disabled={wildTileInputs.size === 0 || Array.from(wildTileInputs.values()).some(v => !/[A-Z]/.test(v))} className="flex-1">
+              <Button onClick={handleWildSubmit} disabled={(() => {
+              const wildcardPositions = pendingWildPath?.filter(p => specialTiles[p.r][p.c].type === "wild") || [];
+              if (wildcardPositions.length === 0) return true;
+              return wildcardPositions.some(pos => {
+                const wildKey = `${pos.r}-${pos.c}`;
+                return !/^[A-Z]$/.test(wildTileInputs.get(wildKey) || '');
+              });
+            })()} className="flex-1">
                 Submit Word
               </Button>
             </div>

--- a/src/components/game/WordPathGame.tsx
+++ b/src/components/game/WordPathGame.tsx
@@ -4445,7 +4445,10 @@ function WordPathGame({
         
         for (let r = 0; r < size; r++) {
           for (let c = 0; c < size; c++) {
-            positions.push({ r, c });
+            // Freeze protects tiles from being replaced/shuffled by other tile effects
+            if (!newSpecialTiles[r][c].frozen) {
+              positions.push({ r, c });
+            }
           }
         }
         

--- a/src/components/game/WordPathGame.tsx
+++ b/src/components/game/WordPathGame.tsx
@@ -876,10 +876,11 @@ function handleXFactorTiles(
   setBoard: (board: string[][]) => void,
   setSpecialTiles: (tiles: SpecialTile[][]) => void,
   setAffectedTiles: (tiles: Set<string>) => void
-): { xChanged: number, board: string[][] } {
+): { xChanged: number, board: string[][], specialTiles: SpecialTile[][] } {
   const xFactorTiles = wordPath.filter(p => specialTiles[p.r][p.c].type === "xfactor");
   let xChanged = 0;
   let resultBoard = currentBoard;
+  let resultTiles = specialTiles.map(row => row.map(tile => ({ ...tile })));
   
   if (xFactorTiles.length > 0) {
     const newBoard = currentBoard.map(row => [...row]);
@@ -926,6 +927,7 @@ function handleXFactorTiles(
     resultBoard = validation.board;
     setBoard(resultBoard);
     setSpecialTiles(newSpecialTiles);
+    resultTiles = newSpecialTiles;
     setAffectedTiles(changedTileKeys);
     xChanged = changedTileKeys.size;
 
@@ -936,7 +938,7 @@ function handleXFactorTiles(
     toast.info("X-Factor activated! Adjacent tiles transformed!");
   }
   
-  return { xChanged, board: resultBoard };
+  return { xChanged, board: resultBoard, specialTiles: resultTiles };
 }
 
 // Apply Magnet spawn effect: replace orthogonal neighbors with random vowels
@@ -1029,7 +1031,7 @@ function handleBombBlast(
   setBoard: (board: string[][]) => void,
   setSpecialTiles: (tiles: SpecialTile[][]) => void,
   setAffectedTiles: (tiles: Set<string>) => void
-): string[][] {
+): { board: string[][], specialTiles: SpecialTile[][] } {
   const newBoard = board.map(row => [...row]);
   const newTiles = specialTiles.map(row => row.map(t => ({ ...t })));
   const changedKeys = new Set<string>();
@@ -1071,7 +1073,7 @@ function handleBombBlast(
   setTimeout(() => setAffectedTiles(new Set()), 1500);
   toast.info("Bomb detonated! Area reset with new letters!");
   
-  return validation.board;
+  return { board: validation.board, specialTiles: newTiles };
 }
 
 function checkAndAwardAchievements(
@@ -2207,6 +2209,7 @@ function WordPathGame({
     );
     const xChanged = xFactorResult.xChanged;
     trackedBoard = xFactorResult.board;
+    let trackedSpecialTiles = xFactorResult.specialTiles;
 
     // Handle shuffle tiles (use updated board from X-factor)
     trackedBoard = handleShuffleTiles(
@@ -2222,15 +2225,17 @@ function WordPathGame({
     const bombTilesInPath = wordPath.filter(p => specialTiles[p.r][p.c].type === "bomb");
     if (bombTilesInPath.length > 0) {
       for (const bombPos of bombTilesInPath) {
-        trackedBoard = handleBombBlast(bombPos, trackedBoard, specialTiles, size, setBoard, setSpecialTiles, setAffectedTiles);
+        const bombResult = handleBombBlast(bombPos, trackedBoard, trackedSpecialTiles, size, setBoard, setSpecialTiles, setAffectedTiles);
+        trackedBoard = bombResult.board;
+        trackedSpecialTiles = bombResult.specialTiles;
       }
     }
 
-    let newSpecialTiles = specialTiles.map(row => [...row]);
+    let newSpecialTiles = trackedSpecialTiles.map(row => row.map(tile => ({ ...tile })));
     wordPath.forEach(p => {
-      if (specialTiles[p.r][p.c].type !== null) {
+      if (newSpecialTiles[p.r][p.c].type !== null) {
         newSpecialTiles[p.r][p.c] = {
-          ...specialTiles[p.r][p.c],
+          ...newSpecialTiles[p.r][p.c],
           type: null
         };
       }
@@ -4236,6 +4241,7 @@ function WordPathGame({
     );
     const xChanged = xFactorResult.xChanged;
     trackedBoard = xFactorResult.board;
+    let trackedSpecialTiles = xFactorResult.specialTiles;
 
     // Handle shuffle tiles (use updated board from X-factor)
     trackedBoard = handleShuffleTiles(
@@ -4251,15 +4257,17 @@ function WordPathGame({
     const bombTilesInPath = path.filter(p => specialTiles[p.r][p.c].type === "bomb");
     if (bombTilesInPath.length > 0) {
       for (const bombPos of bombTilesInPath) {
-        trackedBoard = handleBombBlast(bombPos, trackedBoard, specialTiles, size, setBoard, setSpecialTiles, setAffectedTiles);
+        const bombResult = handleBombBlast(bombPos, trackedBoard, trackedSpecialTiles, size, setBoard, setSpecialTiles, setAffectedTiles);
+        trackedBoard = bombResult.board;
+        trackedSpecialTiles = bombResult.specialTiles;
       }
     }
 
-    let newSpecialTiles = specialTiles.map(row => [...row]);
+    let newSpecialTiles = trackedSpecialTiles.map(row => row.map(tile => ({ ...tile })));
     path.forEach(p => {
-      if (specialTiles[p.r][p.c].type !== null) {
+      if (newSpecialTiles[p.r][p.c].type !== null) {
         newSpecialTiles[p.r][p.c] = {
-          ...specialTiles[p.r][p.c],
+          ...newSpecialTiles[p.r][p.c],
           type: null
         };
       }

--- a/src/components/game/WordPathGame.tsx
+++ b/src/components/game/WordPathGame.tsx
@@ -2684,6 +2684,7 @@ function WordPathGame({
             }
           }
         }
+        trackedBoard = currentBoard;
       }
 
       setSpecialTiles(updatedSpecialTiles);
@@ -2708,7 +2709,7 @@ function WordPathGame({
       if (sorted && dict) {
         // Check if daily challenge is out of moves
         const dailyMovesExceeded = (settings.mode === "daily" || settings.mode === "daily_5x5") && movesUsed + 1 >= settings.dailyMovesLimit;
-        const any = hasAnyValidMove(newBoard, lastWordTiles.size ? lastWordTiles : new Set(wordPath.map(keyOf)), dict, sorted, new Set(usedWords.map(entry => entry.word)));
+        const any = hasAnyValidMove(trackedBoard, lastWordTiles.size ? lastWordTiles : new Set(wordPath.map(keyOf)), dict, sorted, new Set(usedWords.map(entry => entry.word)));
         if (!any || dailyMovesExceeded) {
           if (benchmarks) {
             let grade: "Bronze" | "Silver" | "Gold" | "Platinum" | "None" = "None";
@@ -4412,6 +4413,7 @@ function WordPathGame({
             }
           }
         }
+        trackedBoard = currentBoard;
       }
 
       setSpecialTiles(updatedSpecialTiles);
@@ -4437,7 +4439,7 @@ function WordPathGame({
     if (settings.mode === "chaos" && chaosStarted && dict && sorted) {
       setTimeout(() => {
         // Keep some random tiles, shuffle others
-        const newBoard = board.map(row => [...row]);
+        const newBoard = trackedBoard.map(row => [...row]);
         const tilesToReshuffle = Math.floor(Math.random() * 5) + 3; // 3-7 tiles reshuffled
         const positions: Pos[] = [];
         
@@ -4568,9 +4570,9 @@ function WordPathGame({
     // Check if game over due to stone tiles blocking all valid words (Classic, Zen, Chaos, or Endless mode)
     if ((settings.mode === "classic" || settings.mode === "zen" || (settings.mode === "chaos" && chaosStarted) || (settings.mode === "endless" && endlessStarted)) && dict && sorted) {
       // Create a test grid with stone tiles marked as blocked
-      const testGrid = board.map((row, r) => 
+      const testGrid = trackedBoard.map((row, r) => 
         row.map((letter, c) => 
-          specialTiles[r][c].type === "stone" ? "" : letter
+          newSpecialTiles[r][c].type === "stone" ? "" : letter
         )
       );
       
@@ -4650,7 +4652,7 @@ function WordPathGame({
         const dailyMovesExceeded = (settings.mode === "daily" || settings.mode === "daily_5x5") && movesUsed + 1 >= settings.dailyMovesLimit;
         // Check if puzzle mode is out of moves
         const puzzleMovesExceeded = puzzleMode && puzzleMovesRemaining <= 1;
-        const any = hasAnyValidMove(board, lastWordTiles.size ? lastWordTiles : new Set(path.map(keyOf)), dict, sorted, new Set(usedWords.map(entry => entry.word)));
+        const any = hasAnyValidMove(trackedBoard, lastWordTiles.size ? lastWordTiles : new Set(path.map(keyOf)), dict, sorted, new Set(usedWords.map(entry => entry.word)));
         if (!any || dailyMovesExceeded || puzzleMovesExceeded) {
           // Handle puzzle mode - check completion on move limit
           if (puzzleMode && puzzleMovesExceeded && currentPuzzleId) {

--- a/src/components/game/WordPathGame.tsx
+++ b/src/components/game/WordPathGame.tsx
@@ -2652,7 +2652,7 @@ function WordPathGame({
         const numTilesToPlace = Math.floor(Math.random() * 3) + 1;
         const tilesToPlace = Math.min(numTilesToPlace, emptyPositions.length);
         newWildPositions = [];
-        let currentBoard = board;
+        let currentBoard = trackedBoard;
         for (let i = 0; i < tilesToPlace; i++) {
           const randomIndex = Math.floor(Math.random() * emptyPositions.length);
           const pos = emptyPositions.splice(randomIndex, 1)[0];
@@ -4377,7 +4377,7 @@ function WordPathGame({
         const numTilesToPlace = Math.floor(Math.random() * 3) + 1;
         const tilesToPlace = Math.min(numTilesToPlace, emptyPositions.length);
         newWildPositions = [];
-        let currentBoard = board;
+        let currentBoard = trackedBoard;
         for (let i = 0; i < tilesToPlace; i++) {
           const randomIndex = Math.floor(Math.random() * emptyPositions.length);
           const pos = emptyPositions.splice(randomIndex, 1)[0];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fixed Wild tile submit handling to support paths containing multiple Wild special tiles
- validated and collected a letter for every Wild tile before attempting dictionary validation
- routed submissions to the existing multi-wild submission path when needed
- updated the Wild tile dialog UI to render one input per Wild tile and only enable submit when all entries are valid letters
- fixed special-tile sequencing so post-word spawn effects (e.g. Magnet) apply to the latest transformed board state instead of stale pre-effect board data
- fixed chained special-effect state propagation so X-Factor/Bomb mutations to special tile state are preserved through the rest of the turn logic (instead of being overwritten by stale state)
- fixed turn-end validation/chaos reshuffle checks to use post-effect board/tile state, preventing stale-state move-availability and stone-block evaluations
- fixed shuffle and bomb triggering logic to evaluate against the latest tile state after X-Factor transformations
- fixed Chaos reshuffles to respect Freeze protections and avoid mutating frozen tiles

## Testing
- `npm run build` ✅
- `npm run lint` ❌ (pre-existing repository-wide lint violations unrelated to this change)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7701f57b-5441-46c8-be65-075342c94be9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7701f57b-5441-46c8-be65-075342c94be9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

